### PR TITLE
feat: add gating telemetry to execution reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Each hourly run pushes the full execution report JSON to an orphan `logs` branch
 
 On the 1st of each month (UTC 00:00), the **Monthly Execution Report** workflow aggregates all hourly logs from the previous month, creates a structured review bundle, and opens a GitHub Issue labeled `monthly-review`.
 
-An **AI Monthly Review** workflow triggers on that issue label and posts a bilingual (English + Chinese) analysis covering trade execution quality, circuit breaker events, degraded mode episodes, PnL breakdown, upstream pool impact, error patterns, and earn buffer efficiency.
+An **AI Monthly Review** workflow triggers on that issue label and posts a bilingual (English + Chinese) analysis covering trade execution quality, no-trade / gating reasons, circuit breaker events, degraded mode episodes, PnL breakdown, upstream pool impact, error patterns, and earn buffer efficiency.
 
 ### Workflows
 
@@ -425,6 +425,7 @@ This emits a structured JSON report with:
 - trend buy/sell intents
 - BTC DCA intents
 - earn subscribe/redeem intents
+- explicit gating / no-trade reason counts
 - suppressed vs executed side-effect counts
 
 ### Tests

--- a/application/execution_service.py
+++ b/application/execution_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from runtime_support import record_gating_event
+
 
 def run_daily_circuit_breaker(
     runtime,
@@ -30,6 +32,13 @@ def run_daily_circuit_breaker(
     for symbol, config in runtime_trend_universe.items():
         tradable_qty = balances[symbol]
         if tradable_qty * prices[symbol] <= 10:
+            record_gating_event(
+                report,
+                gate="circuit_breaker_sell_below_min_position",
+                category="trend",
+                symbol=symbol,
+                detail={"position_value_usdt": round(tradable_qty * prices[symbol], 4)},
+            )
             continue
         qty = format_qty_fn(runtime.client, symbol, tradable_qty)
         report["buy_sell_intents"].append(
@@ -225,9 +234,22 @@ def execute_trend_buys(
         candidate_meta = selected_candidates[symbol]
         buy_u = planned_trend_buys.get(symbol, 0.0)
         if buy_u <= 15:
+            record_gating_event(
+                report,
+                gate="trend_buy_below_min_budget",
+                category="trend",
+                symbol=symbol,
+                detail={"budget_usdt": round(float(buy_u), 4)},
+            )
             continue
 
         if should_skip_duplicate_trend_action_fn(state, symbol, "buy", today_id_str):
+            record_gating_event(
+                report,
+                gate="trend_buy_duplicate_cooldown",
+                category="trend",
+                symbol=symbol,
+            )
             append_log_fn(log_buffer, translate_fn("duplicate_buy_skipped", symbol=symbol))
             continue
 
@@ -246,6 +268,13 @@ def execute_trend_buys(
         )
         try:
             if qty <= 0 or usdt_cost <= 0:
+                record_gating_event(
+                    report,
+                    gate="trend_buy_zero_order_size",
+                    category="trend",
+                    symbol=symbol,
+                    detail={"budget_usdt": round(float(buy_u), 4)},
+                )
                 runtime_notify_fn(
                     runtime,
                     report,
@@ -341,6 +370,13 @@ def execute_trend_rotation(
     )
     report["selected_symbols"]["active_trend_pool"] = list(active_trend_pool)
     report["selected_symbols"]["selected_candidates"] = list(selected_candidates.keys())
+    if not selected_candidates:
+        record_gating_event(
+            report,
+            gate="trend_no_selected_candidate",
+            category="trend",
+            detail={"active_trend_pool_size": len(active_trend_pool)},
+        )
 
     append_rotation_summary(
         log_buffer,
@@ -379,6 +415,16 @@ def execute_trend_rotation(
         current_allocation["trend_usdt_pool"],
         allow_new_trend_entries,
     )
+    if selected_candidates and not eligible_buy_symbols:
+        record_gating_event(
+            report,
+            gate="trend_no_eligible_buy",
+            category="trend",
+            detail={
+                "selected_candidate_count": len(selected_candidates),
+                "allow_new_trend_entries": bool(allow_new_trend_entries),
+            },
+        )
     u_total = execute_trend_buys(
         runtime,
         report,
@@ -448,6 +494,15 @@ def execute_btc_dca_cycle(
     runtime_set_trade_state_fn,
 ):
     if dca_usdt_pool <= 10 and dca_val <= 10:
+        record_gating_event(
+            report,
+            gate="btc_dca_pool_too_small",
+            category="btc_dca",
+            detail={
+                "dca_usdt_pool": round(float(dca_usdt_pool), 4),
+                "dca_val": round(float(dca_val), 4),
+            },
+        )
         return u_total
 
     btc_price = prices["BTCUSDT"]
@@ -466,6 +521,27 @@ def execute_btc_dca_cycle(
 
     base_order = get_dynamic_btc_base_order(total_equity)
     multiplier = _resolve_btc_buy_multiplier(ahr)
+
+    if multiplier <= 0:
+        record_gating_event(
+            report,
+            gate="btc_dca_buy_valuation_gate_off",
+            category="btc_dca",
+            detail={"ahr999": round(float(ahr), 4)},
+        )
+    elif dca_usdt_pool <= 15:
+        record_gating_event(
+            report,
+            gate="btc_dca_buy_below_min_budget",
+            category="btc_dca",
+            detail={"dca_usdt_pool": round(float(dca_usdt_pool), 4)},
+        )
+    elif state.get("dca_last_buy_date") == today_id_str:
+        record_gating_event(
+            report,
+            gate="btc_dca_buy_duplicate_cooldown",
+            category="btc_dca",
+        )
 
     if multiplier > 0 and dca_usdt_pool > 15 and state.get("dca_last_buy_date") != today_id_str:
         budget = min(dca_usdt_pool, base_order * multiplier)
@@ -521,6 +597,21 @@ def execute_btc_dca_cycle(
                 f"{translate_fn('btc_dca_buy_failed')} BTC\n"
                 f"{translate_fn('error_label')}: {exc}",
             )
+
+    if zscore > sell_trigger and dca_val <= 20:
+        record_gating_event(
+            report,
+            gate="btc_dca_sell_below_min_position",
+            category="btc_dca",
+            detail={"dca_val": round(float(dca_val), 4), "zscore": round(float(zscore), 4)},
+        )
+    elif zscore > sell_trigger and state.get("dca_last_sell_date") == today_id_str:
+        record_gating_event(
+            report,
+            gate="btc_dca_sell_duplicate_cooldown",
+            category="btc_dca",
+            detail={"zscore": round(float(zscore), 4)},
+        )
 
     if zscore > sell_trigger and dca_val > 20 and state.get("dca_last_sell_date") != today_id_str:
         sell_pct = _resolve_btc_trim_sell_pct(zscore)

--- a/application/state_service.py
+++ b/application/state_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from runtime_support import record_gating_event
+
 
 def load_cycle_state(
     runtime,
@@ -36,6 +38,13 @@ def load_cycle_state(
 
     runtime_trend_universe = get_runtime_trend_universe(state)
     allow_new_trend_entries = (not trend_pool_resolution["degraded"]) or allow_new_trend_entries_on_degraded
+    if trend_pool_resolution["degraded"] and not allow_new_trend_entries:
+        record_gating_event(
+            report,
+            gate="trend_buy_paused_degraded_mode",
+            category="trend",
+            detail=str(trend_pool_resolution.get("source", "unknown")),
+        )
     return state, trend_pool_resolution, runtime_trend_universe, allow_new_trend_entries
 
 

--- a/docs/operator_runbook.md
+++ b/docs/operator_runbook.md
@@ -51,6 +51,7 @@ Runtime output should stay operational:
 - current upstream source and degraded status
 - upstream official pool and current local execution pool logged as separate concepts
 - current execution targets and intents
+- explicit gating / no-trade reasons and side-effect suppression counts
 - exceptions, circuit breakers, and alert-worthy failures
 
 The monthly execution pool is locked to the accepted upstream `version` / `as_of_date`. It is rebuilt when upstream release metadata changes and otherwise reused across cycles.

--- a/runtime_support.py
+++ b/runtime_support.py
@@ -48,6 +48,8 @@ def build_execution_report(runtime):
             "executed_call_count": 0,
             "suppressed_call_count": 0,
         },
+        "gating_summary": {},
+        "gating_events": [],
         "error_summary": {
             "errors": [],
         },
@@ -62,6 +64,24 @@ def build_execution_report(runtime):
 
 def append_report_error(report, message, *, stage="runtime"):
     report["error_summary"]["errors"].append({"stage": str(stage), "message": str(message)})
+
+
+def record_gating_event(report, *, gate, category, symbol=None, detail=None):
+    gate_name = str(gate)
+    category_name = str(category)
+    summary = report.setdefault("gating_summary", {})
+    events = report.setdefault("gating_events", [])
+    summary[gate_name] = int(summary.get(gate_name, 0) or 0) + 1
+
+    event = {
+        "gate": gate_name,
+        "category": category_name,
+    }
+    if symbol:
+        event["symbol"] = str(symbol)
+    if detail is not None:
+        event["detail"] = detail
+    events.append(event)
 
 
 def record_side_effect(runtime, report, *, effect_type, target, payload, executed):

--- a/scripts/run_monthly_report_bundle.py
+++ b/scripts/run_monthly_report_bundle.py
@@ -59,6 +59,12 @@ def aggregate_hourly_reports(hourly_dir: str, report_month: str) -> dict[str, An
     total_runs = len(entries)
     successful_runs = 0
     failed_runs = 0
+    dry_run_runs = 0
+
+    # --- side effects / gating ---
+    executed_side_effects = 0
+    suppressed_side_effects = 0
+    gating_counts: dict[str, int] = {}
 
     # --- trade summary accumulators ---
     btc_buys = 0
@@ -91,6 +97,8 @@ def aggregate_hourly_reports(hourly_dir: str, report_month: str) -> dict[str, An
     for fname, report in entries:
         status = report.get("status", "ok")
         run_id = report.get("run_id", fname)
+        if report.get("dry_run"):
+            dry_run_runs += 1
 
         # Success / failure
         if status == "ok":
@@ -106,6 +114,14 @@ def aggregate_hourly_reports(hourly_dir: str, report_month: str) -> dict[str, An
             if start_equity is None:
                 start_equity = float(equity)
             end_equity = float(equity)
+
+        side_effect_summary = report.get("side_effect_summary") or {}
+        executed_side_effects += int(side_effect_summary.get("executed_call_count", 0) or 0)
+        suppressed_side_effects += int(side_effect_summary.get("suppressed_call_count", 0) or 0)
+
+        for gate, count in (report.get("gating_summary") or {}).items():
+            gate_name = str(gate)
+            gating_counts[gate_name] = gating_counts.get(gate_name, 0) + int(count or 0)
 
         # BTC DCA intents
         for intent in report.get("btc_dca_intents", []) or []:
@@ -172,6 +188,15 @@ def aggregate_hourly_reports(hourly_dir: str, report_month: str) -> dict[str, An
             "total_runs": total_runs,
             "successful_runs": successful_runs,
             "failed_runs": failed_runs,
+            "dry_run_runs": dry_run_runs,
+        },
+        "side_effect_summary": {
+            "executed_call_count": executed_side_effects,
+            "suppressed_call_count": suppressed_side_effects,
+        },
+        "execution_gating": {
+            "total_events": int(sum(gating_counts.values())),
+            "counts": dict(sorted(gating_counts.items())),
         },
         "trade_summary": {
             "btc_core": {
@@ -217,6 +242,8 @@ def format_review_markdown(bundle: dict[str, Any]) -> str:
     stats = bundle["run_statistics"]
     trade = bundle["trade_summary"]
     pnl = bundle["pnl_overview"]
+    side_effects = bundle["side_effect_summary"]
+    gating = bundle["execution_gating"]
     cb_events = bundle["circuit_breaker_events"]
     dg_events = bundle["degraded_mode_events"]
     pool_changes = bundle["upstream_pool_changes"]
@@ -234,10 +261,11 @@ def format_review_markdown(bundle: dict[str, Any]) -> str:
     lines.append("## Report Scope")
     lines.append("")
     lines.append("- This is BinancePlatform's downstream monthly execution review, not a pure upstream pool publication.")
-    lines.append("- It summarizes runtime health, recorded trade intents, earn buffer operations, circuit breaker activity, degraded mode, and upstream pool changes.")
+    lines.append("- It summarizes runtime health, recorded trade intents, no-trade / gating reasons, earn buffer operations, circuit breaker activity, degraded mode, and upstream pool changes.")
     lines.append("- Upstream pool changes are included as execution context from CryptoLeaderRotation, but they are only one input section of this report.")
     lines.append("- Equity deltas in this report are raw month-start vs month-end snapshots and may include manual deposits, withdrawals, or other external balance flows.")
     lines.append("- Trade and earn sections reflect execution intents/actions recorded in hourly reports, not a separate exchange fill reconciliation ledger.")
+    lines.append("- Side-effect counts indicate how many client / notification / state-write calls were actually executed versus suppressed (for example in dry-run or replay contexts).")
     lines.append("")
 
     # Run statistics
@@ -248,11 +276,33 @@ def format_review_markdown(bundle: dict[str, Any]) -> str:
     lines.append(f"| Total runs | {stats['total_runs']} |")
     lines.append(f"| Successful runs | {stats['successful_runs']} |")
     lines.append(f"| Failed runs | {stats['failed_runs']} |")
+    lines.append(f"| Dry-run runs | {stats['dry_run_runs']} |")
     success_rate = (
         round(stats["successful_runs"] / stats["total_runs"] * 100, 1)
         if stats["total_runs"] > 0 else 0
     )
     lines.append(f"| Success rate | {success_rate}% |")
+    lines.append("")
+
+    # Side effects
+    lines.append("## Side Effects")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    lines.append(f"| Executed calls | {side_effects['executed_call_count']} |")
+    lines.append(f"| Suppressed calls | {side_effects['suppressed_call_count']} |")
+    lines.append("")
+
+    # Gating summary
+    lines.append("## Execution Gating / No-Trade Reasons")
+    lines.append("")
+    if gating["counts"]:
+        lines.append("| Gate | Count |")
+        lines.append("|------|-------|")
+        for gate_name, count in sorted(gating["counts"].items(), key=lambda item: (-item[1], item[0])):
+            lines.append(f"| {gate_name} | {count} |")
+    else:
+        lines.append("_No explicit gating or no-trade reasons were recorded this month._")
     lines.append("")
 
     # PnL overview
@@ -363,11 +413,12 @@ def format_review_markdown(bundle: dict[str, Any]) -> str:
     lines.append("## Review Questions")
     lines.append("")
     lines.append("1. Does the equity trend look explainable once possible external deposits/withdrawals are considered?")
-    lines.append("2. Were any circuit breaker events justified, or do thresholds need adjusting?")
-    lines.append("3. Did upstream pool changes have a noticeable impact on performance?")
-    lines.append("4. Are the failed runs isolated incidents or part of a pattern?")
-    lines.append("5. Do the recorded trade intents suggest BTC DCA cadence or trend sizing should be adjusted?")
-    lines.append("6. Were earn buffer subscribe/redeem operations executed at appropriate times?")
+    lines.append("2. Do the recorded gating / no-trade reasons look expected, or do any thresholds / cooldowns appear too restrictive?")
+    lines.append("3. Were any circuit breaker events justified, or do thresholds need adjusting?")
+    lines.append("4. Did upstream pool changes have a noticeable impact on performance?")
+    lines.append("5. Are the failed runs isolated incidents or part of a pattern?")
+    lines.append("6. Do the recorded trade intents suggest BTC DCA cadence or trend sizing should be adjusted?")
+    lines.append("7. Were earn buffer subscribe/redeem operations executed at appropriate times?")
     lines.append("")
 
     return "\n".join(lines)

--- a/tests/test_execution_service.py
+++ b/tests/test_execution_service.py
@@ -111,7 +111,7 @@ class ExecutionServiceTests(unittest.TestCase):
 
     def test_execute_trend_buys_executes_buy_and_updates_runtime_state(self):
         runtime = SimpleNamespace(client=object())
-        report = {"buy_sell_intents": []}
+        report = {"buy_sell_intents": [], "gating_summary": {}, "gating_events": []}
         state = {}
         balances = {"ETHUSDT": 0.0}
         prices = {"ETHUSDT": 100.0}
@@ -161,6 +161,40 @@ class ExecutionServiceTests(unittest.TestCase):
         self.assertEqual(observed["actions"], [("ETHUSDT", "buy", "20260329")])
         self.assertEqual(observed["persist_reasons"], ["trend_buy:ETHUSDT"])
         self.assertGreaterEqual(len(observed["notifications"]), 1)
+
+    def test_execute_trend_buys_records_gate_when_budget_below_threshold(self):
+        runtime = SimpleNamespace(client=object())
+        report = {"buy_sell_intents": [], "gating_summary": {}, "gating_events": []}
+
+        result = execute_trend_buys(
+            runtime,
+            report,
+            {},
+            {"ETHUSDT": {"weight": 0.6, "relative_score": 1.2}},
+            ["ETHUSDT"],
+            {"ETHUSDT": 12.0},
+            {"ETHUSDT": 100.0},
+            {"ETHUSDT": 0.0},
+            500.0,
+            [],
+            "20260329",
+            should_skip_duplicate_trend_action_fn=lambda *_args: False,
+            append_log_fn=lambda *_args: None,
+            translate_fn=lambda key, **_kwargs: key,
+            format_qty_fn=lambda *_args: 0.0,
+            ensure_asset_available_fn=lambda *_args: True,
+            runtime_call_client_fn=lambda *_args, **_kwargs: None,
+            next_order_id_fn=lambda *_args: "buy-order-id",
+            set_symbol_trade_state_fn=lambda *_args, **_kwargs: None,
+            record_trend_action_fn=lambda *_args, **_kwargs: None,
+            runtime_set_trade_state_fn=lambda *_args, **_kwargs: None,
+            runtime_notify_fn=lambda *_args, **_kwargs: None,
+        )
+
+        self.assertEqual(result, 500.0)
+        self.assertEqual(report["buy_sell_intents"], [])
+        self.assertEqual(report["gating_summary"]["trend_buy_below_min_budget"], 1)
+        self.assertEqual(report["gating_events"][0]["symbol"], "ETHUSDT")
 
     def test_execute_trend_rotation_delegates_sell_buy_and_status_flow(self):
         runtime = SimpleNamespace(now_utc="2026-03-29T00:00:00Z")
@@ -242,7 +276,7 @@ class ExecutionServiceTests(unittest.TestCase):
 
     def test_execute_btc_dca_cycle_executes_buy_branch(self):
         runtime = SimpleNamespace(client=object())
-        report = {"btc_dca_intents": []}
+        report = {"btc_dca_intents": [], "gating_summary": {}, "gating_events": []}
         state = {}
         balances = {"BTCUSDT": 0.1}
         prices = {"BTCUSDT": 50_000.0}
@@ -287,7 +321,7 @@ class ExecutionServiceTests(unittest.TestCase):
 
     def test_execute_btc_dca_cycle_executes_trim_branch(self):
         runtime = SimpleNamespace(client=object())
-        report = {"btc_dca_intents": []}
+        report = {"btc_dca_intents": [], "gating_summary": {}, "gating_events": []}
         state = {}
         balances = {"BTCUSDT": 1.0}
         prices = {"BTCUSDT": 10_000.0}
@@ -329,6 +363,39 @@ class ExecutionServiceTests(unittest.TestCase):
         self.assertEqual(observed["asset_checks"][0][0], "BTC")
         self.assertEqual(observed["client_calls"][0][0], "order_market_sell")
         self.assertEqual(observed["persist_reasons"], ["btc_dca_sell"])
+
+    def test_execute_btc_dca_cycle_records_gate_when_pool_too_small(self):
+        runtime = SimpleNamespace(client=object())
+        report = {"btc_dca_intents": [], "gating_summary": {}, "gating_events": []}
+
+        result = execute_btc_dca_cycle(
+            runtime,
+            report,
+            {},
+            {"BTCUSDT": 0.0},
+            {"BTCUSDT": 50_000.0},
+            100.0,
+            1_000.0,
+            8.0,
+            6.0,
+            {"ahr999": 0.7, "zscore": 0.0, "sell_trigger": 3.5},
+            0.25,
+            "20260329",
+            [],
+            append_log_fn=lambda *_args: None,
+            translate_fn=lambda key, **_kwargs: key,
+            get_dynamic_btc_base_order=lambda _total_equity: 50.0,
+            format_qty_fn=lambda *_args: 0.0,
+            ensure_asset_available_fn=lambda *_args: True,
+            runtime_call_client_fn=lambda *_args, **_kwargs: None,
+            next_order_id_fn=lambda *_args: "noop",
+            runtime_notify_fn=lambda *_args, **_kwargs: None,
+            runtime_set_trade_state_fn=lambda *_args, **_kwargs: None,
+        )
+
+        self.assertEqual(result, 100.0)
+        self.assertEqual(report["btc_dca_intents"], [])
+        self.assertEqual(report["gating_summary"]["btc_dca_pool_too_small"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_monthly_report_bundle.py
+++ b/tests/test_monthly_report_bundle.py
@@ -9,11 +9,13 @@ class TestMonthlyReportBundle(unittest.TestCase):
                      trend_equity=200.0, circuit_breaker=False,
                      degraded_level=None, pool_symbols=None,
                      buy_sell_intents=None, btc_dca_intents=None,
-                     redemption_intents=None, errors=None):
+                     redemption_intents=None, errors=None,
+                     gating_summary=None, dry_run=False,
+                     executed_calls=0, suppressed_calls=0):
         return {
             "status": status,
             "run_id": run_id,
-            "dry_run": False,
+            "dry_run": dry_run,
             "total_equity_usdt": total_equity,
             "trend_equity_usdt": trend_equity,
             "circuit_breaker_triggered": circuit_breaker,
@@ -30,9 +32,11 @@ class TestMonthlyReportBundle(unittest.TestCase):
             },
             "notifications": [],
             "state_write_intents": [],
+            "gating_summary": gating_summary or {},
+            "gating_events": [],
             "side_effect_summary": {
-                "executed_call_count": 0,
-                "suppressed_call_count": 0,
+                "executed_call_count": executed_calls,
+                "suppressed_call_count": suppressed_calls,
             },
         }
 
@@ -57,6 +61,7 @@ class TestMonthlyReportBundle(unittest.TestCase):
         self.assertEqual(bundle["run_statistics"]["total_runs"], 3)
         self.assertEqual(bundle["run_statistics"]["successful_runs"], 3)
         self.assertEqual(bundle["run_statistics"]["failed_runs"], 0)
+        self.assertEqual(bundle["run_statistics"]["dry_run_runs"], 0)
         self.assertEqual(bundle["pnl_overview"]["start_equity_usdt"], 1000.0)
         self.assertEqual(bundle["pnl_overview"]["end_equity_usdt"], 1050.0)
 
@@ -141,3 +146,40 @@ class TestMonthlyReportBundle(unittest.TestCase):
         self.assertIn("not a pure upstream pool publication", md)
         self.assertIn("external balance flows", md)
         self.assertIn("recorded strategy intents", md)
+        self.assertIn("Execution Gating / No-Trade Reasons", md)
+
+    def test_aggregate_gating_and_side_effects(self):
+        from scripts.run_monthly_report_bundle import aggregate_hourly_reports, format_review_markdown
+
+        reports = {
+            "2026-03-01T0000.json": self._make_report(
+                "r1",
+                dry_run=True,
+                executed_calls=1,
+                suppressed_calls=3,
+                gating_summary={"trend_buy_below_min_budget": 2},
+            ),
+            "2026-03-01T0100.json": self._make_report(
+                "r2",
+                executed_calls=2,
+                suppressed_calls=0,
+                gating_summary={"btc_dca_pool_too_small": 1, "trend_buy_below_min_budget": 1},
+            ),
+        }
+        with tempfile.TemporaryDirectory() as td:
+            hourly_dir = os.path.join(td, "hourly", "2026-03")
+            os.makedirs(hourly_dir)
+            for fname, data in reports.items():
+                with open(os.path.join(hourly_dir, fname), "w") as f:
+                    json.dump(data, f)
+
+            bundle = aggregate_hourly_reports(hourly_dir, "2026-03")
+            md = format_review_markdown(bundle)
+
+        self.assertEqual(bundle["run_statistics"]["dry_run_runs"], 1)
+        self.assertEqual(bundle["side_effect_summary"]["executed_call_count"], 3)
+        self.assertEqual(bundle["side_effect_summary"]["suppressed_call_count"], 3)
+        self.assertEqual(bundle["execution_gating"]["counts"]["trend_buy_below_min_budget"], 3)
+        self.assertEqual(bundle["execution_gating"]["counts"]["btc_dca_pool_too_small"], 1)
+        self.assertIn("trend_buy_below_min_budget", md)
+        self.assertIn("Dry-run runs", md)

--- a/tests/test_runtime_support.py
+++ b/tests/test_runtime_support.py
@@ -1,5 +1,6 @@
 import unittest
-from runtime_support import ExecutionRuntime, build_execution_report
+
+from runtime_support import ExecutionRuntime, build_execution_report, record_gating_event
 
 
 class TestBuildExecutionReport(unittest.TestCase):
@@ -11,6 +12,8 @@ class TestBuildExecutionReport(unittest.TestCase):
         self.assertFalse(report["circuit_breaker_triggered"])
         self.assertIsNone(report["degraded_mode_level"])
         self.assertEqual(report["upstream_pool_symbols"], [])
+        self.assertEqual(report["gating_summary"], {})
+        self.assertEqual(report["gating_events"], [])
 
     def test_report_preserves_existing_fields(self):
         runtime = ExecutionRuntime(dry_run=False, run_id="test-002")
@@ -20,3 +23,23 @@ class TestBuildExecutionReport(unittest.TestCase):
         self.assertFalse(report["dry_run"])
         self.assertIn("buy_sell_intents", report)
         self.assertIn("log_lines", report)
+
+    def test_record_gating_event_updates_summary_and_events(self):
+        report = {}
+
+        record_gating_event(
+            report,
+            gate="trend_buy_below_min_budget",
+            category="trend",
+            symbol="ETHUSDT",
+            detail={"budget_usdt": 12.0},
+        )
+        record_gating_event(
+            report,
+            gate="trend_buy_below_min_budget",
+            category="trend",
+        )
+
+        self.assertEqual(report["gating_summary"]["trend_buy_below_min_budget"], 2)
+        self.assertEqual(report["gating_events"][0]["symbol"], "ETHUSDT")
+        self.assertEqual(report["gating_events"][0]["detail"]["budget_usdt"], 12.0)

--- a/tests/test_state_service.py
+++ b/tests/test_state_service.py
@@ -31,7 +31,7 @@ class StateServiceTests(unittest.TestCase):
 
     def test_load_cycle_state_refreshes_runtime_state_metadata(self):
         runtime = SimpleNamespace(name="runtime")
-        report = {"status": "ok"}
+        report = {"status": "ok", "gating_summary": {}, "gating_events": []}
         observed = {"trend_universe": None, "persist_reasons": []}
         raw_state = {"foo": "bar"}
         normalized_state = {"normalized": True}
@@ -61,6 +61,30 @@ class StateServiceTests(unittest.TestCase):
             result,
             (normalized_state, trend_pool_resolution, runtime_trend_universe, True),
         )
+
+    def test_load_cycle_state_records_degraded_buy_pause_gate(self):
+        report = {"status": "ok", "gating_summary": {}, "gating_events": []}
+
+        result = load_cycle_state(
+            SimpleNamespace(),
+            report,
+            allow_new_trend_entries_on_degraded=False,
+            state_loader=lambda *, normalize: {"ok": True},
+            resolve_runtime_trend_pool=lambda *_args, **_kwargs: (
+                {"ETHUSDT": {"base_asset": "ETH"}},
+                {"degraded": True, "source_kind": "last_known_good", "source": "last_known_good"},
+            ),
+            normalize_trade_state=lambda state: state,
+            update_trend_pool_state=lambda *_args, **_kwargs: None,
+            runtime_set_trade_state=lambda *_args, **_kwargs: None,
+            get_runtime_trend_universe=lambda state: {"ETHUSDT": {"base_asset": "ETH"}},
+            append_report_error=lambda *_args, **_kwargs: None,
+            trend_universe_setter=lambda _value: None,
+        )
+
+        self.assertFalse(result[3])
+        self.assertEqual(report["gating_summary"]["trend_buy_paused_degraded_mode"], 1)
+        self.assertEqual(report["gating_events"][0]["category"], "trend")
 
     def test_append_trend_pool_source_logs_appends_all_lines(self):
         log_buffer = []


### PR DESCRIPTION
## Summary
- record explicit no-trade and gating reasons in hourly execution reports for degraded mode, trend buys, BTC DCA, and circuit-breaker skips
- surface gating counts, dry-run runs, and side-effect suppression totals in the monthly execution bundle and markdown review
- document the new telemetry fields and cover them with regression tests

## Verification
- uv run --with requests==2.32.5 python -m unittest tests/test_runtime_support.py tests/test_state_service.py tests/test_execution_service.py tests/test_monthly_report_bundle.py tests/test_monthly_report_workflow_config.py tests/test_post_monthly_ai_review_comment.py
- uvx ruff check application infra runtime_support.py scripts tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/monthly_report.yml"); YAML.load_file(".github/workflows/ai_review.yml"); puts "yaml ok"' 