### PR TITLE
chore: upgrade workflow actions for node24

### DIFF
--- a/.github/workflows/ai_review.yml
+++ b/.github/workflows/ai_review.yml
@@ -18,9 +18,12 @@ jobs:
       id-token: write
       issues: write
 
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Load review issue context
         id: issue_context

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
     steps:
       - name: 1. Checkout latest code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: 2. Authenticate to Google Cloud
         uses: google-github-actions/auth@v3

--- a/.github/workflows/monthly_report.yml
+++ b/.github/workflows/monthly_report.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Determine report month
         id: month

--- a/tests/test_monthly_report_workflow_config.py
+++ b/tests/test_monthly_report_workflow_config.py
@@ -14,6 +14,7 @@ class MonthlyReportWorkflowConfigTests(unittest.TestCase):
         workflow = MONTHLY_REPORT_WORKFLOW.read_text(encoding="utf-8")
 
         self.assertIn("actions: write", workflow)
+        self.assertIn("actions/checkout@v6", workflow)
         self.assertIn('--hourly-dir "hourly/${{ steps.month.outputs.month }}"', workflow)
         self.assertIn("gh label create monthly-review", workflow)
         self.assertIn("gh workflow run ai_review.yml", workflow)
@@ -31,6 +32,7 @@ class MonthlyReportWorkflowConfigTests(unittest.TestCase):
         self.assertIn("steps.issue_context.outputs.issue_body", workflow)
         self.assertIn("id: claude_review", workflow)
         self.assertIn("github_token: ${{ secrets.GITHUB_TOKEN }}", workflow)
+        self.assertIn('FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"', workflow)
         self.assertIn("${{ inputs.issue_number || github.event.issue.number }}", workflow)
         self.assertIn("Do not use Bash or ask for additional approval.", workflow)
         self.assertIn("The workflow will publish your final review as the issue comment.", workflow)


### PR DESCRIPTION
## Summary
- upgrade checkout to the current major in all workflows
- force Node 24 for the Claude AI review workflow until upstream action versions fully move off Node 20
- keep existing workflow logic unchanged

## Verification
- python3 -m unittest tests/test_monthly_report_workflow_config.py
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "yaml ok"' 