### PR TITLE
feat: standardize ai review payload

### DIFF
--- a/.github/workflows/ai_review.yml
+++ b/.github/workflows/ai_review.yml
@@ -221,6 +221,17 @@ jobs:
             --output-file data/output/ai_review/final_review.md \
             --primary-title "Claude Primary Review"
 
+      - name: Build final AI review payload
+        if: steps.claude_review.outcome == 'success'
+        run: |
+          python3 scripts/build_ai_review_payload.py \
+            --source-repo "${GITHUB_REPOSITORY}" \
+            --review-kind execution_runtime \
+            --issue-context-file data/output/ai_review/issue_context.json \
+            --secondary-review-file data/output/ai_review/secondary_review.json \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --output-file data/output/ai_review/final_review_payload.json
+
       - name: Upload AI review artifact
         if: steps.claude_review.outcome == 'success'
         uses: actions/upload-artifact@v7

--- a/scripts/build_ai_review_payload.py
+++ b/scripts/build_ai_review_payload.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "2026-04-02"
+REPO_ROLE_BY_KIND = {
+    "upstream_selector": "upstream_selector_review",
+    "execution_runtime": "execution_runtime_review",
+}
+
+
+def build_review_payload(
+    *,
+    source_repo: str,
+    review_kind: str,
+    issue_context: dict[str, Any],
+    secondary_review: dict[str, Any],
+    run_url: str,
+) -> dict[str, Any]:
+    if review_kind not in REPO_ROLE_BY_KIND:
+        raise ValueError(f"Unsupported review kind: {review_kind}")
+
+    issue_number = int(issue_context["number"])
+    issue_title = str(issue_context["title"]).strip()
+    issue_url = f"https://github.com/{source_repo}/issues/{issue_number}"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_repo": source_repo,
+        "repo_role": REPO_ROLE_BY_KIND[review_kind],
+        "review_kind": review_kind,
+        "source_issue": {
+            "number": issue_number,
+            "title": issue_title,
+            "url": issue_url,
+        },
+        "run_url": run_url.strip(),
+        "primary_reviewer": {
+            "provider": "anthropic",
+            "display_name": "Claude Primary Review",
+        },
+        "secondary_reviewer": {
+            "provider": secondary_review["provider"],
+            "display_name": secondary_review["provider_display_name"],
+            "model": secondary_review["model"],
+        },
+        "verdict": secondary_review["verdict"],
+        "risk_level": secondary_review["risk_level"],
+        "production_recommendation": secondary_review["production_recommendation"],
+        "summary": secondary_review["summary"],
+        "key_findings": list(secondary_review.get("key_findings", [])),
+        "recommended_actions": list(secondary_review.get("recommended_actions", [])),
+        "follow_up_checks": list(secondary_review.get("follow_up_checks", [])),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build the normalized final AI review payload used by downstream planners.",
+    )
+    parser.add_argument("--source-repo", required=True)
+    parser.add_argument("--review-kind", required=True, choices=sorted(REPO_ROLE_BY_KIND))
+    parser.add_argument("--issue-context-file", required=True, type=Path)
+    parser.add_argument("--secondary-review-file", required=True, type=Path)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--output-file", required=True, type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    issue_context = json.loads(args.issue_context_file.read_text(encoding="utf-8"))
+    secondary_review = json.loads(args.secondary_review_file.read_text(encoding="utf-8"))
+    payload = build_review_payload(
+        source_repo=args.source_repo,
+        review_kind=args.review_kind,
+        issue_context=issue_context,
+        secondary_review=secondary_review,
+        run_url=args.run_url,
+    )
+    args.output_file.parent.mkdir(parents=True, exist_ok=True)
+    args.output_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"final_review_payload={args.output_file}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_ai_review_payload.py
+++ b/tests/test_build_ai_review_payload.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.build_ai_review_payload import SCHEMA_VERSION, build_review_payload
+
+
+class BuildAiReviewPayloadTests(unittest.TestCase):
+    def test_build_review_payload_carries_standardized_root_fields(self) -> None:
+        payload = build_review_payload(
+            source_repo="QuantStrategyLab/BinancePlatform",
+            review_kind="execution_runtime",
+            issue_context={"number": 9, "title": "Monthly Execution Review: 2026-03"},
+            secondary_review={
+                "provider": "openai",
+                "provider_display_name": "GPT Secondary Review",
+                "model": "gpt-5.4-mini",
+                "verdict": "agree",
+                "risk_level": "low",
+                "production_recommendation": "keep_production_as_is",
+                "summary": "Looks consistent.",
+                "key_findings": ["No blocking issue found."],
+                "recommended_actions": [],
+                "follow_up_checks": [],
+            },
+            run_url="https://github.com/example/repo/actions/runs/1",
+        )
+
+        self.assertEqual(payload["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(payload["repo_role"], "execution_runtime_review")
+        self.assertEqual(payload["source_issue"]["url"], "https://github.com/QuantStrategyLab/BinancePlatform/issues/9")
+        self.assertEqual(payload["secondary_reviewer"]["model"], "gpt-5.4-mini")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_monthly_report_workflow_config.py
+++ b/tests/test_monthly_report_workflow_config.py
@@ -44,10 +44,12 @@ class MonthlyReportWorkflowConfigTests(unittest.TestCase):
         self.assertIn("post_monthly_ai_review_comment.py", workflow)
         self.assertIn("render_monthly_ai_review.py", workflow)
         self.assertIn("run_openai_secondary_review.py", workflow)
+        self.assertIn("build_ai_review_payload.py", workflow)
         self.assertIn("steps.claude_review.outputs.execution_file", workflow)
         self.assertIn("OPENAI_API_KEY", workflow)
         self.assertIn("OPENAI_SECONDARY_MODEL", workflow)
         self.assertIn("secondary_review.json", workflow)
+        self.assertIn("final_review_payload.json", workflow)
         self.assertIn("actions/upload-artifact@v7", workflow)
 
 


### PR DESCRIPTION
## Summary
- add a normalized final AI review payload artifact for the monthly dual-AI review workflow
- keep the existing Claude + GPT flow but publish final_review_payload.json for downstream planners
- cover the payload contract with unit tests and workflow config checks

## Testing
- python3 -m unittest tests/test_build_ai_review_payload.py tests/test_post_monthly_ai_review_comment.py tests/test_render_monthly_ai_review.py tests/test_run_openai_secondary_review.py tests/test_monthly_report_workflow_config.py
- uvx ruff check scripts tests
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "bp yaml ok"'