### PR TITLE
[codex] Use released artifact contract dependencies

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.12
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@v0.4.4
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.17
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@v0.4.6
 python-binance==1.0.36
 pandas==3.0.2
 numpy==2.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.12
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@v0.4.4
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.17
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@v0.4.6
 python-binance
 pandas
 numpy


### PR DESCRIPTION
## Summary
- bump BinancePlatform runtime dependencies to quant-platform-kit v0.7.17 and crypto-strategies v0.4.6
- fixes the live runtime ImportError where crypto-strategies imported StrategyArtifactContract from an older quant-platform-kit tag

## Validation
- PYTHONPATH=.:/home/ubuntu/Projects/QuantPlatformKit/src:/home/ubuntu/Projects/CryptoStrategies/src /home/ubuntu/Projects/UsEquityStrategies/.venv/bin/python -m unittest tests.test_strategy_runtime tests.test_runtime_config_support tests.test_trend_pool_loading -v
- python3 -m ruff check .
- python3 -m compileall strategy_artifact_support.py trend_pool_support.py degraded_mode_support.py runtime_config_support.py strategy_runtime.py scripts tests
- git diff --check
- /tmp/binance-qpk-compat-venv2/bin/python -c "import main; print(main.STRATEGY_RUNTIME.artifact_contract)"
- /tmp/binance-qpk-compat-venv2/bin/pip check