### PR TITLE
[codex] Update core dependency pins

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.17
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@v0.4.6
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.35
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@v0.4.7
 python-binance==1.0.36
 pandas==3.0.3
 numpy==2.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.17
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@v0.4.6
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.35
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@v0.4.7
 python-binance
 pandas
 numpy


### PR DESCRIPTION
## Summary
- pin QuantPlatformKit to v0.7.35
- pin CryptoStrategies to v0.4.7 in both requirements files

## Validation
- `timeout 120s python3 -m py_compile application/cycle_service.py application/state_service.py degraded_mode_support.py entrypoints/cli.py infra/state_store.py market_snapshot_support.py main.py notify_i18n_support.py reporting/status_reports.py research/backtest.py run_cycle_replay.py runtime_config_support.py runtime_support.py strategy_loader.py strategy_runtime.py decision_mapper.py live_services.py`
- `timeout 120s env PYTHONPATH=/home/ubuntu/Projects/QuantPlatformKit/src:/home/ubuntu/Projects/CryptoStrategies/src:. python3 -m unittest discover -s tests -v` (blocked locally by missing numpy/pandas in system Python; GitHub CI installs requirements-lock.txt)
