### PR TITLE
Add bilingual docs summaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Contributing
 
+
+## 中文摘要
+
+- 用途：本文档围绕 `Contributing`，用于理解 `BinancePlatform` 的配置、运行、部署、研究或验收边界。
+- 主要覆盖：`Ground Rules`、`Branching and Pull Requests`、`Local Verification`。
+- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
+- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
+- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
 Thanks for contributing to `BinancePlatform`.
 
 ## Ground Rules

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,6 +2,16 @@
 
 > ⚠️ 投资有风险，不构成投资建议，仅供学习交流用途。
 
+
+## English summary
+
+- Full English version: [`README.md`](README.md). This summary keeps an English entry point in the Chinese file.
+- Purpose: this document covers `BinancePlatform` for `BinancePlatform`.
+- Main topics: `仓库形态`, `文件说明`, `执行日志`, `工作流`, `所需 Secrets`.
+- Read the boundaries, inputs, outputs, and permission requirements before running commands, CI jobs, dry-runs, releases, or runtime switches.
+- For live trading, secrets, Cloud Run, exchange, or broker API changes, validate in test or dry-run mode first and do not change production only from examples.
+- If this summary differs from the detailed Chinese body, follow the concrete commands, configuration keys, and constraints in the body.
+
 语言: [English](README.md) | 简体中文
 
 这是一个运行在 Binance 现货上的自动化量化项目，核心由两部分组成：

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,13 @@
 # Security Policy
 
+
+## 中文摘要
+
+- 用途：本文档围绕 `Security Policy`，用于理解 `BinancePlatform` 的配置、运行、部署、研究或验收边界。
+- 主要覆盖：`Reporting a Vulnerability`、`Secret and Credential Exposure`、`Scope Notes`。
+- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
+- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
+- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
 Thanks for helping keep `BinancePlatform` safe.
 
 This repository is part of a runtime trading platform. Please do **not** open a public issue for vulnerabilities involving credentials, broker access, cloud resources, order execution, or secret material.

--- a/docs/binance_platform_rename_checklist.md
+++ b/docs/binance_platform_rename_checklist.md
@@ -1,5 +1,13 @@
 # BinancePlatform Rename Checklist
 
+
+## 中文摘要
+
+- 用途：本文档围绕 `BinancePlatform Rename Checklist`，用于理解 `BinancePlatform` 的配置、运行、部署、研究或验收边界。
+- 主要覆盖：`Current status`、`Why this rename is different from Cloud Run repos`、`Confirmed impact points`、`External runtime dependencies`、`Repo-internal references`。
+- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
+- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
+- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
 _Last reviewed: 2026-03-30_
 
 This checklist records the completed runtime repository rename from `BinanceQuant` to `BinancePlatform`.

--- a/docs/operator_runbook.md
+++ b/docs/operator_runbook.md
@@ -1,5 +1,14 @@
 # Operator Runbook
 
+
+## 中文摘要
+
+- 用途：本文档围绕 `Operator Runbook`，用于理解 `BinancePlatform` 的配置、运行、部署、研究或验收边界。
+- 主要覆盖：`Scope`、`Execution Boundary`、`Normal Live Flow`、`Runtime Trigger Model`、`Degraded Mode Ladder`。
+- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
+- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
+- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
+
 ## Scope
 
 This runbook covers the live execution path in `BinancePlatform`.


### PR DESCRIPTION
## Summary
- Add bilingual summary entry points to repository documentation.
- Keep existing detailed docs intact while adding Chinese or English summaries where missing.
- Add cross-language navigation for paired English / zh-CN docs where available.

## Validation
- Custom bilingual coverage scan: coverage_issues=0.
- git diff --check passed.

## Deployment note
Documentation-only change; no runtime code, secrets, production env, or deployment settings changed.
