### PR TITLE
Notify Telegram on Binance workflow failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,3 +154,35 @@ jobs:
           git push origin "HEAD:${LOGS_BRANCH}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 7. Notify Telegram on runtime workflow failure
+        if: ${{ failure() && github.event.inputs.validate_only != 'true' }}
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          if [ -z "${TG_TOKEN:-}" ] || [ -z "${GLOBAL_TELEGRAM_CHAT_ID:-}" ]; then
+            echo "Telegram workflow failure notification skipped: target is not configured."
+            exit 0
+          fi
+
+          REPORT_FILE="${GITHUB_WORKSPACE}/reports/execution_report.json"
+          if [ -f "$REPORT_FILE" ]; then
+            echo "Execution report exists; strategy-level runtime handling should already have recorded this failure."
+            exit 0
+          fi
+
+          MESSAGE=$(printf '%s\n' \
+            "Binance Runtime workflow failed before execution report was written" \
+            "repo: ${GITHUB_REPOSITORY}" \
+            "workflow: ${GITHUB_WORKFLOW}" \
+            "run: #${GITHUB_RUN_NUMBER} attempt ${GITHUB_RUN_ATTEMPT}" \
+            "ref: ${GITHUB_REF_NAME}" \
+            "sha: ${GITHUB_SHA}" \
+            "actor: ${GITHUB_ACTOR}" \
+            "url: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}")
+          curl -fsS -X POST "https://api.telegram.org/bot${TG_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${GLOBAL_TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}" >/dev/null
+        env:
+          TG_TOKEN: ${{ secrets.TG_TOKEN }}
+          GLOBAL_TELEGRAM_CHAT_ID: ${{ vars.GLOBAL_TELEGRAM_CHAT_ID }}

--- a/tests/test_runtime_workflow_shared_config.sh
+++ b/tests/test_runtime_workflow_shared_config.sh
@@ -11,6 +11,10 @@ grep -Fq "STRATEGY_PROFILE: \${{ vars.STRATEGY_PROFILE || 'crypto_leader_rotatio
 grep -Fq 'id-token: write' "$workflow_file"
 grep -Fq 'workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}' "$workflow_file"
 grep -Fq 'service_account: ${{ env.GCP_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}' "$workflow_file"
+grep -Fq '7. Notify Telegram on runtime workflow failure' "$workflow_file"
+grep -Fq "if: \${{ failure() && github.event.inputs.validate_only != 'true' }}" "$workflow_file"
+grep -Fq 'reports/execution_report.json' "$workflow_file"
+grep -Fq 'https://api.telegram.org/bot${TG_TOKEN}/sendMessage' "$workflow_file"
 if grep -Fq 'TG_CHAT_ID:' "$workflow_file"; then
   echo "workflow should not pass TG_CHAT_ID anymore" >&2
   exit 1


### PR DESCRIPTION
## Summary
- add a final Runtime workflow failure notification step for Binance
- send Telegram directly from shell/curl when the workflow fails before an execution report exists
- keep validate-only runs quiet and avoid duplicating strategy-level failure notifications when a report was written
- extend the workflow config guard test so this fallback is not removed accidentally

## Tests
- bash tests/test_runtime_workflow_shared_config.sh
- /usr/bin/python3 YAML parse of .github/workflows/main.yml
- git diff --check