### PR TITLE
Show redacted Binance dispatch script

### DIFF
--- a/.github/workflows/runner-scheduler-diagnostics.yml
+++ b/.github/workflows/runner-scheduler-diagnostics.yml
@@ -80,3 +80,18 @@ jobs:
             | sort \
             | head -200 \
             | redact || true
+
+          section "dispatch script redacted"
+          if [ -f /home/ubuntu/binance-quant/ops/dispatch-runtime.sh ]; then
+            sed -n '1,240p' /home/ubuntu/binance-quant/ops/dispatch-runtime.sh | redact
+          else
+            echo "dispatch-runtime.sh not found"
+          fi
+
+          section "dispatch env keys"
+          if [ -f /home/ubuntu/.config/binance-platform/dispatch.env ]; then
+            sed -E 's/(^[[:space:]]*(export[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*=).*/\1[REDACTED]/' \
+              /home/ubuntu/.config/binance-platform/dispatch.env | redact
+          else
+            echo "dispatch.env not found"
+          fi


### PR DESCRIPTION
## Summary
- extend the manual scheduler diagnostics workflow with redacted dispatch script output
- print dispatch env variable names without values so scheduler notification handling can be audited safely

## Tests
- /usr/bin/python3 YAML parse of .github/workflows/runner-scheduler-diagnostics.yml
- git diff --check