### PR TITLE
Install Binance dispatch failure guard

### DIFF
--- a/.github/workflows/install-dispatch-guard.yml
+++ b/.github/workflows/install-dispatch-guard.yml
@@ -1,0 +1,141 @@
+name: Install Dispatch Guard
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    runs-on: self-hosted
+    timeout-minutes: 5
+    env:
+      TG_TOKEN: ${{ secrets.TG_TOKEN }}
+      GLOBAL_TELEGRAM_CHAT_ID: ${{ vars.GLOBAL_TELEGRAM_CHAT_ID }}
+    steps:
+      - name: Install guarded dispatch script
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${TG_TOKEN:-}" ] || [ -z "${GLOBAL_TELEGRAM_CHAT_ID:-}" ]; then
+            echo "TG_TOKEN and GLOBAL_TELEGRAM_CHAT_ID must be configured before installing dispatch guard." >&2
+            exit 1
+          fi
+
+          ENV_FILE="$HOME/.config/binance-platform/dispatch.env"
+          SCRIPT_PATH="$HOME/binance-quant/ops/dispatch-runtime.sh"
+          mkdir -p "$(dirname "$ENV_FILE")" "$(dirname "$SCRIPT_PATH")"
+
+          if [ -f "$SCRIPT_PATH" ]; then
+            cp "$SCRIPT_PATH" "${SCRIPT_PATH}.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+          fi
+
+          python3 - "$ENV_FILE" <<'PY'
+          import os
+          import shlex
+          import sys
+          from pathlib import Path
+
+          path = Path(sys.argv[1])
+          updates = {
+              "TG_TOKEN": os.environ["TG_TOKEN"],
+              "GLOBAL_TELEGRAM_CHAT_ID": os.environ["GLOBAL_TELEGRAM_CHAT_ID"],
+          }
+          existing = path.read_text().splitlines() if path.exists() else []
+          keys = set(updates)
+          kept = [
+              line
+              for line in existing
+              if not line.strip().split("=", 1)[0].removeprefix("export ").strip() in keys
+          ]
+          for key, value in updates.items():
+              kept.append(f"{key}={shlex.quote(value)}")
+          tmp = path.with_suffix(path.suffix + ".tmp")
+          tmp.write_text("\n".join(kept) + "\n")
+          tmp.chmod(0o600)
+          tmp.replace(path)
+          PY
+
+          cat > "$SCRIPT_PATH" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          ENV_FILE="${BINANCE_PLATFORM_DISPATCH_ENV:-$HOME/.config/binance-platform/dispatch.env}"
+          LOG_FILE="${BINANCE_PLATFORM_DISPATCH_LOG:-$HOME/binance-quant/ops/dispatch-runtime.log}"
+
+          notify_telegram() {
+            local message="$1"
+            if [ -z "${TG_TOKEN:-}" ] || [ -z "${GLOBAL_TELEGRAM_CHAT_ID:-}" ]; then
+              echo "Telegram dispatch notification skipped: target is not configured." >&2
+              return 0
+            fi
+            curl --fail --silent --show-error \
+              -X POST "https://api.telegram.org/bot${TG_TOKEN}/sendMessage" \
+              --data-urlencode "chat_id=${GLOBAL_TELEGRAM_CHAT_ID}" \
+              --data-urlencode "text=${message}" >/dev/null || \
+              echo "Telegram dispatch notification failed." >&2
+          }
+
+          fail_dispatch() {
+            local reason="$1"
+            local details="${2:-}"
+            local message
+            message=$(printf '%s\n' \
+              "Binance Runtime dispatch failed" \
+              "host: $(hostname)" \
+              "repo: ${REPO:-<unset>}" \
+              "workflow: ${WORKFLOW:-<unset>}" \
+              "ref: ${REF:-<unset>}" \
+              "time_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              "reason: ${reason}" \
+              "${details}")
+            notify_telegram "$message"
+            echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) dispatch failed: ${reason} ${details}" >> "$LOG_FILE"
+            exit 1
+          }
+
+          mkdir -p "$(dirname "$LOG_FILE")"
+
+          [ -f "$ENV_FILE" ] || fail_dispatch "missing env file" "$ENV_FILE"
+          # shellcheck disable=SC1090
+          source "$ENV_FILE"
+
+          for required in GITHUB_TOKEN REPO WORKFLOW REF; do
+            if [ -z "${!required:-}" ]; then
+              fail_dispatch "missing required env" "$required"
+            fi
+          done
+
+          response_file=$(mktemp)
+          stderr_file=$(mktemp)
+          trap 'rm -f "$response_file" "$stderr_file"' EXIT
+
+          set +e
+          http_status=$(curl --silent --show-error \
+            --output "$response_file" \
+            --write-out "%{http_code}" \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW}/dispatches" \
+            -d "{\"ref\":\"${REF}\"}" 2>"$stderr_file")
+          curl_exit=$?
+          set -e
+
+          if [ "$curl_exit" -ne 0 ]; then
+            fail_dispatch "curl exited ${curl_exit}" "$(head -c 800 "$stderr_file")"
+          fi
+
+          if [ "$http_status" != "204" ]; then
+            fail_dispatch "GitHub dispatch returned HTTP ${http_status}" "$(head -c 800 "$response_file")"
+          fi
+
+          echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) dispatched ${REPO}/${WORKFLOW} ref=${REF}" >> "$LOG_FILE"
+          EOF
+
+          chmod 700 "$SCRIPT_PATH"
+          bash -n "$SCRIPT_PATH"
+          echo "Installed guarded Binance dispatch script at $SCRIPT_PATH"


### PR DESCRIPTION
## Summary
- add a manual self-hosted workflow that installs a guarded Binance dispatch script on the runner host
- persist Telegram alert targets into the runner dispatch env using existing repo secrets/vars
- notify Telegram when the hourly GitHub Runtime dispatch fails before any workflow can start
- keep the installer fixed-purpose; it does not trigger the trading Runtime workflow

## Tests
- /usr/bin/python3 YAML parse of .github/workflows/install-dispatch-guard.yml
- git diff --check