### PR TITLE
Add runtime workflow heartbeat alerts

### DIFF
--- a/.github/workflows/runtime-heartbeat.yml
+++ b/.github/workflows/runtime-heartbeat.yml
@@ -1,0 +1,42 @@
+name: Runtime Heartbeat
+
+on:
+  workflow_dispatch:
+    inputs:
+      lookback_hours:
+        description: "Runtime workflow lookback window in hours."
+        required: false
+        type: string
+        default: "2.5"
+      fail_workflow_on_alert:
+        description: "Fail this workflow when an alert is emitted."
+        required: false
+        type: choice
+        default: "true"
+        options:
+          - "true"
+          - "false"
+  schedule:
+    - cron: "35 * * * *"
+
+jobs:
+  heartbeat:
+    name: Check Runtime workflow heartbeat
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    env:
+      RUNTIME_HEARTBEAT_NAME: BinancePlatform Runtime
+      RUNTIME_HEARTBEAT_WORKFLOW: main.yml
+      RUNTIME_HEARTBEAT_LOOKBACK_HOURS: ${{ inputs.lookback_hours || vars.RUNTIME_HEARTBEAT_LOOKBACK_HOURS || '2.5' }}
+      RUNTIME_HEARTBEAT_FAIL_WORKFLOW_ON_ALERT: ${{ inputs.fail_workflow_on_alert || vars.RUNTIME_HEARTBEAT_FAIL_WORKFLOW_ON_ALERT || 'true' }}
+      GLOBAL_TELEGRAM_CHAT_ID: ${{ vars.GLOBAL_TELEGRAM_CHAT_ID }}
+      TG_TOKEN: ${{ secrets.TG_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check recent Runtime workflow success
+        run: python scripts/runtime_workflow_heartbeat.py

--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ Each hourly run pushes the full execution report JSON to an orphan `logs` branch
 
 Recurring monthly execution audits are intentionally not part of this downstream execution repo. Runtime problems should be handled incident-first from failed Runtime / CI checks, Telegram alerts, or operator-observed symptoms. Strategy and snapshot review remains upstream in `CryptoSnapshotPipelines`.
 
+`Runtime Heartbeat` (`.github/workflows/runtime-heartbeat.yml`) is the missed-run
+guard for the VPS/self-hosted execution path. It runs on GitHub-hosted runners,
+does not touch Binance, and checks whether the `Runtime` workflow (`main.yml`)
+has completed successfully within the recent lookback window. If the external
+VPS cron stops dispatching `main.yml`, the self-hosted runner is offline, or the
+latest Runtime run failed, it sends Telegram through `TG_TOKEN` and
+`GLOBAL_TELEGRAM_CHAT_ID`.
+
 ### Workflows
 
 | Workflow | File | Trigger | Runner |
@@ -359,6 +367,7 @@ This repository uses `QuantPlatformKit` for Binance client bootstrap, balance he
 
 - **`.github/workflows/ci.yml`** is the push/manual validation workflow. It runs on GitHub-hosted runners and is limited to install/compile/test checks.
 - **`.github/workflows/main.yml`** is the runtime workflow. It runs on the self-hosted runner, authenticates to Google Cloud with OIDC, prepares the local `venv`, and runs `venv/bin/python main.py`.
+- **`.github/workflows/runtime-heartbeat.yml`** is the GitHub-hosted heartbeat. It checks recent `main.yml` success and alerts on missed or failed Runtime runs.
 - **Triggers:** `ci.yml` runs on `push` to `main` and `workflow_dispatch`; `main.yml` runs on `workflow_dispatch` only.
 - **Runtime cadence:** GitHub Actions no longer schedules hourly runtime execution for this repo. The expected production model is one external scheduler, such as VPS cron + `curl`, calling the GitHub `workflow_dispatch` API for `main.yml`.
 - Use `Actions -> Runtime -> Run workflow` for one-off manual runs.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,6 +64,12 @@
 
 下游执行仓库不再保留周期性月度执行审计。运行问题按 incident-first 方式处理：Runtime / CI 失败、Telegram 告警或操作员观察到异常后再主动修复。策略和 snapshot 审阅留在上游 `CryptoSnapshotPipelines`。
 
+`Runtime Heartbeat`（`.github/workflows/runtime-heartbeat.yml`）是 VPS /
+self-hosted 执行链路的漏跑保护。它跑在 GitHub-hosted runner 上，不连接 Binance，
+只检查 `Runtime` workflow（`main.yml`）在最近窗口内是否成功完成。如果 VPS cron 不再
+dispatch、self-hosted runner 离线，或最新 Runtime run 失败，它会通过 `TG_TOKEN` 和
+`GLOBAL_TELEGRAM_CHAT_ID` 发 Telegram。
+
 ### 工作流
 
 | 工作流 | 文件 | 触发方式 | 运行器 |
@@ -280,6 +286,8 @@ AHR999: 0.45
 
 - [`.github/workflows/main.yml`](./.github/workflows/main.yml) 负责 checkout、通过 OIDC 登录 Google Cloud、准备 venv、执行 `main.py`
 - `push` 只触发校验类 job；真正执行策略的步骤默认只在 `workflow_dispatch` 下运行
+- `.github/workflows/runtime-heartbeat.yml` 跑在 GitHub-hosted runner 上，检查最近的
+  `main.yml` 是否成功完成，并对漏跑或失败 Runtime run 发 Telegram
 - 如需安全验证 self-hosted runner 上的 Google Cloud 登录，可用 `validate_only=true` 手动触发 `main.yml`；这不会下实盘单
 - VPS 侧推荐的运行单元名：`binance-quant`
 - Cloud Run / VPS 的统一部署规则和命名建议见 [`QuantPlatformKit/docs/deployment_model.md`](../QuantPlatformKit/docs/deployment_model.md)

--- a/scripts/runtime_workflow_heartbeat.py
+++ b/scripts/runtime_workflow_heartbeat.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Verify that the Binance Runtime workflow completed successfully recently."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+def _split_values(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    return [part.strip() for part in raw.replace(";", ",").replace("\n", ",").split(",") if part.strip()]
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = (os.environ.get(name) or "").strip().lower()
+    if not value:
+        return default
+    return value in {"1", "true", "yes", "y", "on"}
+
+
+def _parse_timestamp(value: Any) -> dt.datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _github_request(url: str, token: str) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=20) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _list_runtime_runs(
+    *,
+    repository: str,
+    workflow: str,
+    token: str,
+    branch: str,
+    per_page: int,
+) -> list[dict[str, Any]]:
+    query = urllib.parse.urlencode(
+        {
+            "branch": branch,
+            "event": "workflow_dispatch",
+            "per_page": str(per_page),
+        }
+    )
+    url = f"https://api.github.com/repos/{repository}/actions/workflows/{workflow}/runs?{query}"
+    payload = _github_request(url, token)
+    runs = payload.get("workflow_runs")
+    return runs if isinstance(runs, list) else []
+
+
+def _send_telegram(message: str) -> bool:
+    token = os.environ.get("TG_TOKEN") or os.environ.get("TELEGRAM_TOKEN")
+    chats = _split_values(os.environ.get("GLOBAL_TELEGRAM_CHAT_ID"))
+    if not token or not chats:
+        print("Telegram heartbeat notification skipped: target is not configured.", file=sys.stderr)
+        return False
+    ok = True
+    for chat_id in chats:
+        body = urllib.parse.urlencode({"chat_id": chat_id, "text": message}).encode()
+        request = urllib.request.Request(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data=body,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=15) as response:
+                ok = ok and response.status < 400
+        except Exception as exc:  # noqa: BLE001
+            ok = False
+            print(f"Telegram send failed: {exc}", file=sys.stderr)
+    return ok
+
+
+def main() -> int:
+    repository = os.environ.get("GITHUB_REPOSITORY") or "QuantStrategyLab/BinancePlatform"
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise SystemExit("GITHUB_TOKEN is required")
+    workflow = os.environ.get("RUNTIME_HEARTBEAT_WORKFLOW") or "main.yml"
+    branch = os.environ.get("RUNTIME_HEARTBEAT_BRANCH") or "main"
+    name = os.environ.get("RUNTIME_HEARTBEAT_NAME") or "Binance Runtime"
+    lookback_hours = float(os.environ.get("RUNTIME_HEARTBEAT_LOOKBACK_HOURS") or "2.5")
+    per_page = int(os.environ.get("RUNTIME_HEARTBEAT_RUNS_TO_SCAN") or "30")
+    fail_workflow = _env_bool("RUNTIME_HEARTBEAT_FAIL_WORKFLOW_ON_ALERT", True)
+
+    now = dt.datetime.now(dt.timezone.utc)
+    since = now - dt.timedelta(hours=lookback_hours)
+    runs = _list_runtime_runs(
+        repository=repository,
+        workflow=workflow,
+        token=token,
+        branch=branch,
+        per_page=per_page,
+    )
+    recent_runs = []
+    for run in runs:
+        created_at = _parse_timestamp(run.get("created_at"))
+        if created_at and created_at >= since:
+            recent_runs.append(run)
+
+    successful_runs = [run for run in recent_runs if run.get("status") == "completed" and run.get("conclusion") == "success"]
+    latest_run = recent_runs[0] if recent_runs else None
+    issues = []
+    if not recent_runs:
+        issues.append(f"no Runtime workflow_dispatch run found in the last {lookback_hours:g} hours")
+    if not successful_runs:
+        issues.append(f"no successful Runtime workflow run found in the last {lookback_hours:g} hours")
+    if latest_run and latest_run.get("status") == "completed" and latest_run.get("conclusion") != "success":
+        issues.append(
+            f"latest Runtime run completed with conclusion={latest_run.get('conclusion') or '<none>'}"
+        )
+
+    if not issues:
+        latest_success = successful_runs[0]
+        print(
+            "Runtime workflow heartbeat OK: "
+            f"run={latest_success.get('run_number')} "
+            f"created_at={latest_success.get('created_at')} "
+            f"url={latest_success.get('html_url')}"
+        )
+        return 0
+
+    lines = [
+        f"[Runtime Workflow Heartbeat] {name}",
+        f"Lookback: {lookback_hours:g} hours",
+        "Issues:",
+        *[f"- {issue}" for issue in issues],
+    ]
+    if latest_run:
+        lines.extend(
+            [
+                "Latest Runtime run:",
+                f"- run: #{latest_run.get('run_number')} status={latest_run.get('status')} conclusion={latest_run.get('conclusion')}",
+                f"- created_at: {latest_run.get('created_at')}",
+                f"- url: {latest_run.get('html_url')}",
+            ]
+        )
+    if os.environ.get("GITHUB_SERVER_URL") and os.environ.get("GITHUB_RUN_ID"):
+        lines.append(f"Heartbeat workflow: {os.environ['GITHUB_SERVER_URL']}/{repository}/actions/runs/{os.environ['GITHUB_RUN_ID']}")
+    message = "\n".join(lines)
+    print(message)
+    _send_telegram(message[:3900])
+    return 1 if fail_workflow else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a GitHub-hosted Runtime heartbeat for the self-hosted Binance Runtime workflow
- alert Telegram when main.yml has no recent successful workflow_dispatch run or the latest run failed
- document the heartbeat in English and Chinese

## Validation
- python -m py_compile scripts/runtime_workflow_heartbeat.py
- local GitHub API smoke with Telegram disabled
- git diff --check