### PR TITLE
Fix crypto profile notification i18n

### DIFF
--- a/notify_i18n_support.py
+++ b/notify_i18n_support.py
@@ -129,6 +129,7 @@ _TEXTS = {
         "usdt_unavailable_for_trend_buy": "USDT unavailable for trend buy",
         "usdt_unavailable_for_btc_dca_buy": "USDT unavailable for BTC DCA buy",
         "btc_unavailable_for_dca_sell": "BTC unavailable for DCA sell",
+        "strategy_name_crypto_leader_rotation": "Crypto Leader Rotation",
         "strategy_name_crypto_live_pool_rotation": "Crypto Live Pool Rotation",
     },
     "zh": {
@@ -253,6 +254,7 @@ _TEXTS = {
         "usdt_unavailable_for_trend_buy": "USDT 不足，无法执行趋势买入",
         "usdt_unavailable_for_btc_dca_buy": "USDT 不足，无法执行 BTC 定投买入",
         "btc_unavailable_for_dca_sell": "BTC 不足，无法执行定投止盈卖出",
+        "strategy_name_crypto_leader_rotation": "加密领涨轮动",
         "strategy_name_crypto_live_pool_rotation": "加密领涨轮动",
     },
 }

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.35
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@v0.4.7
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@v0.4.8
 python-binance==1.0.36
 pandas==3.0.3
 numpy==2.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.35
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@v0.4.7
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@v0.4.8
 python-binance
 pandas
 numpy

--- a/tests/test_notify_i18n.py
+++ b/tests/test_notify_i18n.py
@@ -79,6 +79,7 @@ for path in (PLATFORM_KIT_SRC, CRYPTO_STRATEGIES_SRC):
 import main
 from degraded_mode_support import format_trend_pool_source_logs
 from market_snapshot_support import capture_market_snapshot
+from notify_i18n_support import build_strategy_display_name, build_translator
 
 
 class FakeClient:
@@ -90,6 +91,14 @@ class FakeClient:
 
 
 class NotifyI18nTests(unittest.TestCase):
+    def test_legacy_strategy_profile_uses_chinese_display_name(self):
+        display_name = build_strategy_display_name(build_translator("zh"))(
+            "crypto_leader_rotation",
+            fallback_name="Crypto Leader Rotation",
+        )
+
+        self.assertEqual(display_name, "加密领涨轮动")
+
     def test_periodic_btc_status_report_uses_chinese_when_notify_lang_is_zh(self):
         state = {}
         messages = []

--- a/tests/test_runtime_config_support.py
+++ b/tests/test_runtime_config_support.py
@@ -62,6 +62,21 @@ class RuntimeConfigSupportTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "Unsupported STRATEGY_PROFILE"):
                 load_cycle_execution_settings()
 
+    def test_load_cycle_execution_settings_accepts_legacy_profile_alias(self):
+        with patch.dict(
+            os.environ,
+            {
+                "STRATEGY_PROFILE": "crypto_leader_rotation",
+                "NOTIFY_LANG": "zh",
+            },
+            clear=False,
+        ):
+            settings = load_cycle_execution_settings()
+
+        self.assertEqual(settings.strategy_profile, DEFAULT_STRATEGY_PROFILE)
+        self.assertEqual(settings.strategy_display_name, "Crypto Live Pool Rotation")
+        self.assertEqual(settings.strategy_display_name_localized, "加密领涨轮动")
+
     def test_platform_supported_profiles_are_filtered_by_registry(self):
         self.assertEqual(
             get_supported_profiles_for_platform(BINANCE_PLATFORM),


### PR DESCRIPTION
## Summary
- localize both crypto_live_pool_rotation and legacy crypto_leader_rotation strategy names in notifications
- update crypto-strategies dependency pin to v0.4.8
- add coverage for legacy profile localization and settings resolution

## Validation
- python -m ruff check notify_i18n_support.py tests/test_notify_i18n.py tests/test_runtime_config_support.py
- PYTHONPATH=.:../QuantPlatformKit/src:../CryptoStrategies/src python -m unittest tests.test_runtime_config_support
- PYTHONPATH=.:../QuantPlatformKit/src:../CryptoStrategies/src python - <<'PY' ... legacy/new notify localization assertions ... PY

## Note
- tests.test_notify_i18n was not runnable on this VPS because the local environment is missing numpy; the failure occurs while importing quant_platform_kit.binance.market_data before test execution.