### PR TITLE
Polish bilingual documentation

### DIFF
--- a/docs/binance_platform_rename_checklist.md
+++ b/docs/binance_platform_rename_checklist.md
@@ -1,13 +1,5 @@
 # BinancePlatform Rename Checklist
 
-
-## 中文摘要
-
-- 用途：本文档围绕 `BinancePlatform Rename Checklist`，用于理解 `BinancePlatform` 的配置、运行、部署、研究或验收边界。
-- 主要覆盖：`Current status`、`Why this rename is different from Cloud Run repos`、`Confirmed impact points`、`External runtime dependencies`、`Repo-internal references`。
-- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
-- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
-- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
 _Last reviewed: 2026-03-30_
 
 This checklist records the completed runtime repository rename from `BinanceQuant` to `BinancePlatform`.

--- a/docs/operator_runbook.md
+++ b/docs/operator_runbook.md
@@ -1,14 +1,5 @@
 # Operator Runbook
 
-
-## 中文摘要
-
-- 用途：本文档围绕 `Operator Runbook`，用于理解 `BinancePlatform` 的配置、运行、部署、研究或验收边界。
-- 主要覆盖：`Scope`、`Execution Boundary`、`Normal Live Flow`、`Runtime Trigger Model`、`Degraded Mode Ladder`。
-- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
-- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
-- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
-
 ## Scope
 
 This runbook covers the live execution path in `BinancePlatform`.


### PR DESCRIPTION
## Summary
- remove generated cross-language summary blocks from Markdown docs
- keep concise language-switch links where paired docs exist
- tighten a few long or stale bilingual doc passages

## Checks
- `rg "## 中文摘要|## English summary|This summary keeps an English entry point|用于理解 .* 的配置、运行、部署、研究或验收边界"` returns no matches in reviewed docs
- local language-link target check
- `git diff --check`