### PR TITLE
[codex] Guard Dependabot auto-merge head SHA

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -22,12 +22,19 @@ jobs:
         run: |
           set -euo pipefail
           BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
-          PR_NUMBER=$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --head "${BRANCH_NAME}" --json number --jq '.[0].number // empty')
+          PR_PAYLOAD=$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --head "${BRANCH_NAME}" --json number,headRefOid --jq '.[0] // {}')
+          PR_NUMBER=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("number", ""))' <<<"${PR_PAYLOAD}")
+          PR_HEAD_SHA=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("headRefOid", ""))' <<<"${PR_PAYLOAD}")
           if [ -z "${PR_NUMBER}" ]; then
             echo "No open Dependabot PR found for ${BRANCH_NAME}." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+          if [ "${PR_HEAD_SHA}" != "${{ github.event.workflow_run.head_sha }}" ]; then
+            echo "Skipping auto-merge: PR #${PR_NUMBER} head ${PR_HEAD_SHA} does not match completed CI head ${{ github.event.workflow_run.head_sha }}." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=${PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Evaluate merge eligibility
         id: merge_guard
@@ -81,4 +88,4 @@ jobs:
         if: steps.merge_guard.outputs.should_merge == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge "${{ steps.pr.outputs.pr_number }}" --repo "${GITHUB_REPOSITORY}" --rebase --delete-branch
+        run: gh pr merge "${{ steps.pr.outputs.pr_number }}" --repo "${GITHUB_REPOSITORY}" --rebase --delete-branch --match-head-commit "${{ steps.pr.outputs.head_sha }}"


### PR DESCRIPTION
## Summary
- fetch the open Dependabot PR `headRefOid` when resolving the workflow-run branch
- skip auto-merge if the current PR head does not match the completed CI run head
- pass `--match-head-commit` to `gh pr merge` to prevent merging an untested updated head

## Root cause
The Dependabot auto-merge workflow was triggered by a successful `workflow_run`, but the merge command did not bind the merge to the exact commit that passed CI. If Dependabot pushed a newer commit between CI completion and the merge step, the workflow could merge a head that was not the one just checked.

## Validation
- `actionlint .github/workflows/dependabot_auto_merge.yml`
- `git diff --check`