### PR TITLE
Fix runtime heartbeat workflow lookup

### DIFF
--- a/scripts/runtime_workflow_heartbeat.py
+++ b/scripts/runtime_workflow_heartbeat.py
@@ -50,7 +50,34 @@ def _github_request(url: str, token: str) -> dict[str, Any]:
         return json.loads(response.read().decode("utf-8"))
 
 
-def _list_runtime_runs(
+def _workflow_paths(workflow: str) -> set[str]:
+    workflow = workflow.strip()
+    paths = {workflow}
+    if "/" not in workflow:
+        paths.add(f".github/workflows/{workflow}")
+    if workflow.startswith(".github/workflows/"):
+        paths.add(workflow.rsplit("/", 1)[-1])
+    return paths
+
+
+def _dedupe_and_sort_runs(runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    unique: dict[str, dict[str, Any]] = {}
+    for run in runs:
+        key = str(run.get("id") or run.get("run_number") or run.get("html_url") or len(unique))
+        unique[key] = run
+
+    def created_at(run: dict[str, Any]) -> dt.datetime:
+        minimum = dt.datetime.min.replace(tzinfo=dt.timezone.utc)
+        return _parse_timestamp(run.get("created_at")) or minimum
+
+    return sorted(
+        unique.values(),
+        key=created_at,
+        reverse=True,
+    )
+
+
+def _list_workflow_runs(
     *,
     repository: str,
     workflow: str,
@@ -69,6 +96,59 @@ def _list_runtime_runs(
     payload = _github_request(url, token)
     runs = payload.get("workflow_runs")
     return runs if isinstance(runs, list) else []
+
+
+def _list_repository_workflow_runs(
+    *,
+    repository: str,
+    workflow: str,
+    token: str,
+    branch: str,
+    per_page: int,
+) -> list[dict[str, Any]]:
+    query = urllib.parse.urlencode(
+        {
+            "branch": branch,
+            "event": "workflow_dispatch",
+            "per_page": str(per_page),
+        }
+    )
+    url = f"https://api.github.com/repos/{repository}/actions/runs?{query}"
+    payload = _github_request(url, token)
+    runs = payload.get("workflow_runs")
+    if not isinstance(runs, list):
+        return []
+    expected_paths = _workflow_paths(workflow)
+    return [run for run in runs if str(run.get("path") or "") in expected_paths]
+
+
+def _list_runtime_runs(
+    *,
+    repository: str,
+    workflow: str,
+    token: str,
+    branch: str,
+    per_page: int,
+) -> list[dict[str, Any]]:
+    workflow_runs = _list_workflow_runs(
+        repository=repository,
+        workflow=workflow,
+        token=token,
+        branch=branch,
+        per_page=per_page,
+    )
+    try:
+        repository_runs = _list_repository_workflow_runs(
+            repository=repository,
+            workflow=workflow,
+            token=token,
+            branch=branch,
+            per_page=per_page,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"Repository-level workflow run lookup skipped: {exc}", file=sys.stderr)
+        repository_runs = []
+    return _dedupe_and_sort_runs([*workflow_runs, *repository_runs])
 
 
 def _send_telegram(message: str) -> bool:

--- a/tests/test_runtime_workflow_heartbeat.py
+++ b/tests/test_runtime_workflow_heartbeat.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+import unittest
+from unittest.mock import patch
+
+from scripts import runtime_workflow_heartbeat as heartbeat
+
+
+def _timestamp(minutes_ago: int) -> str:
+    value = dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=minutes_ago)
+    return value.isoformat().replace("+00:00", "Z")
+
+
+class RuntimeWorkflowHeartbeatTests(unittest.TestCase):
+    def test_repository_runs_fallback_finds_recent_runtime_success(self) -> None:
+        runtime_run = {
+            "id": 1,
+            "run_number": 3083,
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": _timestamp(30),
+            "path": ".github/workflows/main.yml",
+            "html_url": "https://github.com/QuantStrategyLab/BinancePlatform/actions/runs/1",
+        }
+        heartbeat_run = {
+            "id": 2,
+            "run_number": 10,
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": _timestamp(10),
+            "path": ".github/workflows/runtime-heartbeat.yml",
+            "html_url": "https://github.com/QuantStrategyLab/BinancePlatform/actions/runs/2",
+        }
+        requested_urls: list[str] = []
+
+        def fake_github_request(url: str, token: str) -> dict[str, object]:
+            requested_urls.append(url)
+            self.assertEqual(token, "token-1")
+            if "/actions/workflows/main.yml/runs?" in url:
+                return {"workflow_runs": []}
+            if "/actions/runs?" in url:
+                return {"workflow_runs": [heartbeat_run, runtime_run]}
+            self.fail(f"unexpected GitHub API URL: {url}")
+
+        with patch.dict(
+            os.environ,
+            {
+                "GITHUB_REPOSITORY": "QuantStrategyLab/BinancePlatform",
+                "GITHUB_TOKEN": "token-1",
+                "RUNTIME_HEARTBEAT_WORKFLOW": "main.yml",
+                "RUNTIME_HEARTBEAT_LOOKBACK_HOURS": "2.5",
+                "RUNTIME_HEARTBEAT_FAIL_WORKFLOW_ON_ALERT": "true",
+            },
+            clear=True,
+        ):
+            with patch.object(heartbeat, "_github_request", fake_github_request):
+                with patch.object(heartbeat, "_send_telegram") as send_telegram:
+                    self.assertEqual(heartbeat.main(), 0)
+
+        self.assertTrue(any("/actions/workflows/main.yml/runs?" in url for url in requested_urls))
+        self.assertTrue(any("/actions/runs?" in url for url in requested_urls))
+        send_telegram.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a repository-level GitHub Actions runs lookup fallback for the Runtime heartbeat check.
- Filter fallback results by `.github/workflows/main.yml` and merge/dedupe with the original workflow-specific lookup.
- Add a unit test for the case where the workflow endpoint returns no runs but repository runs contain a recent successful Runtime execution.

## Root cause
The failed Runtime Heartbeat run at https://github.com/QuantStrategyLab/BinancePlatform/actions/runs/28098816155 reported no recent Runtime workflow_dispatch runs, even though GitHub had successful Runtime runs at 2026-06-24T10:00:03Z, 11:00:02Z, and 12:00:02Z. The script relied on a single workflow-specific runs endpoint, so an empty response from that endpoint caused a false alert.

## Verification
- `python3 -m unittest tests.test_runtime_workflow_heartbeat`
- `python3 -m py_compile scripts/runtime_workflow_heartbeat.py tests/test_runtime_workflow_heartbeat.py`
- Real API heartbeat check with current gh token: OK, found Runtime run 3084 at 2026-06-24T13:00:02Z