### PR TITLE
fix: align strategy pins with QPK bc5351d

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@bc5351d3567b2bb60416dc969062c37eedbbf65e
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@30b96ceec0e94b08c176d9d83b6d976375c180fb
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@5e9fd5ec0968607d8d9d54e2deb33fdb9ff3d3ec
 python-binance==1.0.37
 pandas==3.0.3
 numpy==2.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@bc5351d3567b2bb60416dc969062c37eedbbf65e
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@30b96ceec0e94b08c176d9d83b6d976375c180fb
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@5e9fd5ec0968607d8d9d54e2deb33fdb9ff3d3ec
 python-binance
 pandas
 numpy


### PR DESCRIPTION
Bump us/hk/crypto strategy SHAs to resolve pip dependency conflict with quant-platform-kit 0.7.39.

Made with [Cursor](https://cursor.com)