### PR TITLE
fix: use full QPK git SHA in requirements

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,4 +1,4 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@bc5351d3567b2bb60416dc969062c37eedbbf65e
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@bc5351d3567b2bb60416dc969062c37eedbbf65e3567b2bb60416dc969062c37eedbbf65e
 crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@5e9fd5ec0968607d8d9d54e2deb33fdb9ff3d3ec
 python-binance==1.0.37
 pandas==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@bc5351d3567b2bb60416dc969062c37eedbbf65e
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@bc5351d3567b2bb60416dc969062c37eedbbf65e3567b2bb60416dc969062c37eedbbf65e
 crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@5e9fd5ec0968607d8d9d54e2deb33fdb9ff3d3ec
 python-binance
 pandas


### PR DESCRIPTION
Pip treats short and full git SHAs as conflicting deps for the same package version.

Made with [Cursor](https://cursor.com)