### PR TITLE
fix: safe dict access in status_reports, return status in save_trade_state & _notify_runtime_error

### DIFF
--- a/live_services.py
+++ b/live_services.py
@@ -35,8 +35,10 @@ def save_trade_state(data, *, normalize_fn, collection="strategy", document="MUL
     try:
         persisted_state = normalize_fn(data)
         get_state_doc_ref(collection=collection, document=document).set(persisted_state)
+        return True
     except Exception as exc:
         print(t("firestore_write_failed", error=exc))
+        return False
 
 
 def send_tg_msg(token, chat_id, text):

--- a/main.py
+++ b/main.py
@@ -455,6 +455,7 @@ def _notify_runtime_error(exc):
         send_tg_msg(token, chat_id, _runtime_error_notification_message(exc))
     except Exception as send_exc:
         print(f"Binance runtime error Telegram send failed: {send_exc}")
+        return False
     return True
 
 # ==========================================

--- a/reporting/status_reports.py
+++ b/reporting/status_reports.py
@@ -49,7 +49,7 @@ def maybe_send_periodic_btc_status_report(
     if not report_bucket or state.get("last_btc_status_report_bucket") == report_bucket:
         return
 
-    gate_text = translate_fn("gate_on") if btc_snapshot["regime_on"] else translate_fn("gate_off")
+    gate_text = translate_fn("gate_on") if btc_snapshot.get("regime_on", False) else translate_fn("gate_off")
     text = (
         f"{translate_fn('heartbeat_title')}\n"
         f"{translate_fn('strategy_label', name=strategy_display_name)}\n"
@@ -114,7 +114,7 @@ def append_portfolio_report(
         log_buffer,
         translate_fn(
             "portfolio_btc_gate_line",
-            gate_text=translate_fn("gate_on") if btc_snapshot["regime_on"] else translate_fn("gate_off"),
+            gate_text=translate_fn("gate_on") if btc_snapshot.get("regime_on", False) else translate_fn("gate_off"),
             ahr=btc_snapshot["ahr999"],
             zscore=btc_snapshot["zscore"],
         ),


### PR DESCRIPTION
fix: safe dict access in status_reports, return status in save_trade_state & _notify_runtime_error

- status_reports.py: use .get() for btc_snapshot regime_on to avoid KeyError
- live_services.py: save_trade_state returns True/False so callers can detect Firestore write failures
- main.py: _notify_runtime_error returns False when Telegram notification fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)