### PR TITLE
chore: bump crypto-strategies to 198027a (adds crypto_btc_dca, crypto_trend_rotation, crypto_equity_combo)

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@bc5351d3567b2bb60416dc969062c37eedbbf65e
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@c028ee06ec15bb1f9b37655b78c9ee57e6c157e3
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@198027a0f7889e7411f97de3ed528aa90191e533
 python-binance
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@bc5351d3567b2bb60416dc969062c37eedbbf65e
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@c028ee06ec15bb1f9b37655b78c9ee57e6c157e3
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@198027a0f7889e7411f97de3ed528aa90191e533
 python-binance
 pandas
 numpy


### PR DESCRIPTION
## Summary
Bump `crypto-strategies` dependency to commit `198027a` to include three new strategies:
- `crypto_btc_dca`: dynamic BTC DCA with equity-scaled allocation
- `crypto_trend_rotation`: altcoin trend-following rotation
- `crypto_equity_combo`: combined BTC DCA + trend rotation with regime-based allocation

## Why
The QuantRuntimeSettings `platform-config.json` now references `crypto_equity_combo` as the default strategy for Binance. The GitHub variable has been synced accordingly. This PR updates the dependency to ensure the strategy code is available at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)