### PR TITLE
fix: btc_snapshot/payload 安全字典访问，防 KeyError

### DIFF
--- a/application/execution_service.py
+++ b/application/execution_service.py
@@ -489,9 +489,9 @@ def execute_btc_dca_cycle(
         return u_total
 
     btc_price = prices["BTCUSDT"]
-    ahr = btc_snapshot["ahr999"]
-    zscore = btc_snapshot["zscore"]
-    sell_trigger = btc_snapshot["sell_trigger"]
+    ahr = btc_snapshot.get("ahr999", 0.0)
+    zscore = btc_snapshot.get("zscore", 0.0)
+    sell_trigger = btc_snapshot.get("sell_trigger", False)
     append_log_fn(
         log_buffer,
         translate_fn(

--- a/decision_mapper.py
+++ b/decision_mapper.py
@@ -52,8 +52,8 @@ def map_strategy_decision_to_rotation_plan(decision: StrategyDecision) -> dict[s
     diagnostics = dict(decision.diagnostics)
     selected_candidates = {
         str(symbol): {
-            "weight": float(payload["weight"]),
-            "relative_score": float(payload["relative_score"]),
+            "weight": float(payload.get("weight", 0.0)),
+            "relative_score": float(payload.get("relative_score", 0.0)),
             "abs_momentum": float(payload.get("abs_momentum", 0.0)),
         }
         for symbol, payload in dict(diagnostics.get("rotation_candidates", {})).items()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@bc5351d3567b2bb60416dc969062c37eedbbf65e
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@e86554b
 crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@198027a0f7889e7411f97de3ed528aa90191e533
 python-binance
 pandas


### PR DESCRIPTION
### 修复
- execution_service.py: btc_snapshot['ahr999'|'zscore'|'sell_trigger'] → .get() 兜底默认值
- decision_mapper.py: payload['weight'|'relative_score'] → .get() 兜底默认值

与已修复的 regime_on 同源，防止外部数据字段缺失导致未捕获 KeyError

### 验证
104 passed ✅