### PR TITLE
fix: restore get_firestore_client & get_state_doc_ref, align cloud param names

### DIFF
--- a/live_services.py
+++ b/live_services.py
@@ -11,13 +11,17 @@ def _get_document_store():
 
 
 def get_firestore_client():
-    """Return the cloud-agnostic document store (backward-compat alias)."""
-    return _get_document_store()
+    """Return the underlying Firestore client for direct collection/document access.
+
+    NOTE: this relies on the GCP provider's ``.client`` property and will
+    raise AttributeError when the active provider is not GCP.
+    """
+    return _get_document_store().client
 
 
-def get_state_doc_ref(collection: str = "strategy", document: str = "MULTI_ASSET_STATE"):
-    """Return a (collection, document_id) tuple for state storage."""
-    return collection, document
+def get_state_doc_ref(*, collection="strategy", document="MULTI_ASSET_STATE"):
+    """Return a Firestore document reference for the given collection/document."""
+    return get_firestore_client().collection(collection).document(document)
 
 
 def load_trade_state(*, normalize_fn, default_state_factory, normalize=True, collection="strategy", document="MULTI_ASSET_STATE"):


### PR DESCRIPTION
## Summary
Fixes `ImportError: cannot import name 'get_firestore_client' from 'live_services'` that broke Runtime workflow #3208.

## Root Cause
Refactoring of `live_services.py` removed `get_firestore_client` and `get_state_doc_ref` in favor of `_get_document_store()`, but `trend_pool_support.py` and `main.py` still import those functions.

## Changes
- Restored `get_firestore_client()` wrapping `DocumentStore.client` (GcpDocumentStore)
- Restored `get_state_doc_ref()` using the Firestore client
- Renamed `gcs_prefix_uri` → `cloud_prefix_uri`, `gcp_project_id` → `project_id` in `cycle_service.py`

## Verification
- `from live_services import get_firestore_client, get_state_doc_ref` ✅
- `from trend_pool_support import infer_base_asset` ✅ (full import chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)