### PR TITLE
chore: bump crypto-strategies pin for get_runtime_enabled_profiles

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@e86554b
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@198027a0f7889e7411f97de3ed528aa90191e533
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@d7eaacaf78bbd62b4b15f46931e1cbe391048e62
 python-binance
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@e86554b
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@198027a0f7889e7411f97de3ed528aa90191e533
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@d7eaacaf78bbd62b4b15f46931e1cbe391048e62
 python-binance
 pandas
 numpy


### PR DESCRIPTION
## Summary
Bumps `crypto-strategies` pin to include the new `get_runtime_enabled_profiles()` export required by `strategy_registry.py`.

Depends on: https://github.com/QuantStrategyLab/CryptoStrategies/commit/d7eaaca

## Fixes
`ImportError: cannot import name 'get_runtime_enabled_profiles' from 'crypto_strategies'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)