### PR TITLE
chore: bump crypto-strategies pin to aee8ffe (v0.4.10)

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@e86554b
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@d7eaacaf78bbd62b4b15f46931e1cbe391048e62
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@aee8ffea9c91565c834ea3f998817f3a079196bc
 python-binance
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@e86554b
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@d7eaacaf78bbd62b4b15f46931e1cbe391048e62
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@aee8ffea9c91565c834ea3f998817f3a079196bc
 python-binance
 pandas
 numpy


### PR DESCRIPTION
## Summary
Bumps `crypto-strategies` pin to include `get_runtime_enabled_profiles()` (v0.4.10).

CI 缓存问题：pip 根据包版本号判断是否需要重装，不会检查 git commit hash。所以即使上次更新了 pin，pip 仍然认为已安装的 0.4.9 已满足版本要求。0.4.10 版本 bump 确保 pip 重新安装。

Depends on: https://github.com/QuantStrategyLab/CryptoStrategies/commit/aee8ffe

🤖 Generated with [Claude Code](https://claude.com/claude-code)