### PR TITLE
fix: bump qpk pin, add Path import, fix cloud_uri plumbing

### DIFF
--- a/application/cycle_service.py
+++ b/application/cycle_service.py
@@ -266,7 +266,7 @@ def run_live_cycle(
     output_printer("\n".join(report.get("log_lines", [])))
     report_path = report_writer(report)
     persisted_local_path = report_path
-    persisted_gcs_uri = None
+    persisted_cloud_uri = None
     try:
         persisted = persist_runtime_report(
             report,
@@ -291,7 +291,7 @@ def run_live_cycle(
         printer=output_printer,
         status=report_status,
         report_path=persisted_local_path,
-        report_gcs_uri=persisted_gcs_uri,
+        report_cloud_uri=persisted_cloud_uri,
         total_equity_usdt=report.get("total_equity_usdt"),
         trend_equity_usdt=report.get("trend_equity_usdt"),
         degraded_mode_level=report.get("degraded_mode_level"),

--- a/main.py
+++ b/main.py
@@ -6,9 +6,10 @@ helpers, and live service adapters live in dedicated modules.
 """
 
 import os
-import time
 import sys
+import time
 import traceback
+from pathlib import Path
 from entrypoints.cli import run_cli_entrypoint
 from notify_i18n_support import build_strategy_display_name, translate as t
 from degraded_mode_support import (

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,4 +1,4 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@e86554b
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@114ed860213691b53c36e878e9df15d1a5d0cc2b
 crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@aee8ffea9c91565c834ea3f998817f3a079196bc
 python-binance
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@e86554b
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@114ed860213691b53c36e878e9df15d1a5d0cc2b
 crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@aee8ffea9c91565c834ea3f998817f3a079196bc
 python-binance
 pandas


### PR DESCRIPTION
## Changes
- Bump `quant-platform-kit` pin to `114ed86` (v0.9.0) — fixes `persist_runtime_report() got an unexpected keyword argument 'cloud_prefix_uri'`
- Add missing `from pathlib import Path` in `main.py`
- Fix `persisted_gcs_uri` → `persisted_cloud_uri` plumbing

## Related
- https://github.com/QuantStrategyLab/QuantPlatformKit/pull/... (v0.7.41→0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)