### PR TITLE
chore: bump crypto-strategies pin to 97c9128 (v0.4.11) for qpk dependency alignment

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@114ed860213691b53c36e878e9df15d1a5d0cc2b
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@aee8ffea9c91565c834ea3f998817f3a079196bc
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@97c9128929ae6b42ef63541e609a4aab7f8a5339
 python-binance
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@114ed860213691b53c36e878e9df15d1a5d0cc2b
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@aee8ffea9c91565c834ea3f998817f3a079196bc
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@97c9128929ae6b42ef63541e609a4aab7f8a5339
 python-binance
 pandas
 numpy


### PR DESCRIPTION
## Summary
Updates `crypto-strategies` pin to v0.4.11 which depends on `quant-platform-kit@114ed86` — matching the direct pin in BinancePlatform. Resolves pip `ResolutionImpossible` error.

## Context
`crypto-strategies@aee8ffe` (0.4.10) still pins `quant-platform-kit@e86554b`, conflicting with BinancePlatform's direct pin of `quant-platform-kit@114ed86`.

Depends on: https://github.com/QuantStrategyLab/CryptoStrategies/commit/97c9128

🤖 Generated with [Claude Code](https://claude.com/claude-code)