### PR TITLE
fix: remove --auto from Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -88,4 +88,4 @@ jobs:
         if: steps.merge_guard.outputs.should_merge == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge "${{ steps.pr.outputs.pr_number }}" --repo "${GITHUB_REPOSITORY}" --rebase --delete-branch --match-head-commit "${{ steps.pr.outputs.head_sha }}" --auto
+        run: gh pr merge "${{ steps.pr.outputs.pr_number }}" --repo "${GITHUB_REPOSITORY}" --rebase --delete-branch --match-head-commit "${{ steps.pr.outputs.head_sha }}"


### PR DESCRIPTION
## Summary
- Remove `--auto` flag from `gh pr merge` in `dependabot_auto_merge.yml`
- `--auto` enables auto-merge which waits for all branch protection rules,
  including required reviews — Dependabot PRs never get approved, so
  auto-merge blocks forever
- Now merges immediately (`--rebase`) since CI already passed and head SHA
  was verified in earlier steps

## Test plan
- [ ] Next Dependabot PR auto-merges without getting stuck