### PR TITLE
Fix Binance watchdog dependency install and auth

### DIFF
--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -6,24 +6,40 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
 
 env:
   GCP_PROJECT_ID: binancequant
-  GCP_WORKLOAD_IDENTITY_PROVIDER: projects/401309731911/locations/global/workloadIdentityPools/github-actions/providers/github-main
-  GCP_WORKLOAD_IDENTITY_SERVICE_ACCOUNT: codex-gcp-operator@binancequant.iam.gserviceaccount.com
+  GCP_WORKLOAD_IDENTITY_PROVIDER: projects/677468735457/locations/global/workloadIdentityPools/github-actions/providers/github-main
+  GCP_WORKLOAD_IDENTITY_SERVICE_ACCOUNT: binance-platform-runtime@binancequant.iam.gserviceaccount.com
 
 jobs:
   check:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}
+          create_credentials_file: true
+          export_environment_variables: true
+          cleanup_credentials: true
       - name: Install deps
-        run: pip install quant-platform-kit google-cloud-firestore
+        run: |
+          set -euo pipefail
+          REQ_FILE="requirements-lock.txt"
+          if [ ! -f "$REQ_FILE" ]; then REQ_FILE="requirements.txt"; fi
+          qpk_req="$(grep -E '^quant-platform-kit @ ' "$REQ_FILE")"
+          python -m pip install --upgrade pip
+          python -m pip install "$qpk_req" google-cloud-firestore
       - name: Run watchdog
         id: check
         run: |

--- a/tests/test_cycle_service.py
+++ b/tests/test_cycle_service.py
@@ -155,8 +155,8 @@ class CycleServiceTests(unittest.TestCase):
         self.assertEqual(persisted_path, output_path)
         self.assertEqual(observed["status"], "ok")
         self.assertEqual(observed["kwargs"]["output_path"], output_path)
-        self.assertEqual(observed["kwargs"]["gcs_prefix_uri"], "gs://demo-bucket/runtime-reports")
-        self.assertEqual(observed["kwargs"]["gcp_project_id"], "demo-project")
+        self.assertEqual(observed["kwargs"]["cloud_prefix_uri"], "gs://demo-bucket/runtime-reports")
+        self.assertEqual(observed["kwargs"]["project_id"], "demo-project")
 
     def test_run_live_cycle_calls_exit_on_error(self):
         observed = {"exit_code": None}

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "watchdog.yml"
+
+
+class WatchdogWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow_text = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_watchdog_uses_binance_runtime_identity(self) -> None:
+        text = self.workflow_text
+
+        self.assertIn("id-token: write", text)
+        self.assertIn(
+            "GCP_WORKLOAD_IDENTITY_PROVIDER: "
+            "projects/677468735457/locations/global/workloadIdentityPools/github-actions/providers/github-main",
+            text,
+        )
+        self.assertIn(
+            "GCP_WORKLOAD_IDENTITY_SERVICE_ACCOUNT: "
+            "binance-platform-runtime@binancequant.iam.gserviceaccount.com",
+            text,
+        )
+        self.assertIn("uses: google-github-actions/auth@v3", text)
+        self.assertIn("workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}", text)
+        self.assertIn("service_account: ${{ env.GCP_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}", text)
+
+    def test_watchdog_installs_locked_internal_dependency(self) -> None:
+        text = self.workflow_text
+
+        self.assertIn("qpk_req=\"$(grep -E '^quant-platform-kit @ ' \"$REQ_FILE\")\"", text)
+        self.assertIn('python -m pip install "$qpk_req" google-cloud-firestore', text)
+        self.assertNotIn("pip install quant-platform-kit google-cloud-firestore", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- install quant-platform-kit from the repository lock file instead of PyPI in the watchdog workflow
- align watchdog Workload Identity settings with the Binance runtime service account
- add a lightweight workflow regression test for auth and dependency wiring

## Verification
- python3 -m unittest tests.test_watchdog_workflow -v
- /usr/bin/python3 -m unittest discover -s tests -p 'test_watchdog_workflow.py' -v
- uv run --with ruff ruff check tests/test_watchdog_workflow.py
- git diff --check