### PR TITLE
Fix watchdog health API usage

### DIFF
--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -13,6 +13,7 @@ env:
   GCP_PROJECT_ID: binancequant
   GCP_WORKLOAD_IDENTITY_PROVIDER: projects/677468735457/locations/global/workloadIdentityPools/github-actions/providers/github-main
   GCP_WORKLOAD_IDENTITY_SERVICE_ACCOUNT: binance-platform-runtime@binancequant.iam.gserviceaccount.com
+  WATCHDOG_MAX_AGE_SECONDS: ${{ vars.WATCHDOG_MAX_AGE_SECONDS || '1800' }}
 
 jobs:
   check:
@@ -43,9 +44,23 @@ jobs:
       - name: Run watchdog
         id: check
         run: |
-          python -c "
-          from quant_platform_kit.common.health import HealthMonitor
-          alive, detail = HealthMonitor().check_alive()
-          print(f'{alive and \"✅\" or \"❌\"} {detail}')
-          exit(0 if alive else 1)
-          "
+          python - <<'PY'
+          import os
+          from quant_platform_kit.common.health import HealthMonitor, is_heartbeat_fresh
+
+          max_age_seconds = int(os.environ.get("WATCHDOG_MAX_AGE_SECONDS", "1800"))
+          heartbeat = HealthMonitor().read()
+          alive = is_heartbeat_fresh(heartbeat, max_age_seconds)
+          if heartbeat is None:
+              detail = "missing heartbeat"
+          else:
+              detail = (
+                  f"status={heartbeat.status} "
+                  f"timestamp={heartbeat.timestamp or '<missing>'} "
+                  f"cycle_count={heartbeat.cycle_count} "
+                  f"last_error={heartbeat.last_error or '<none>'} "
+                  f"max_age_seconds={max_age_seconds}"
+              )
+          print(f"{'OK' if alive else 'FAIL'} {detail}")
+          raise SystemExit(0 if alive else 1)
+          PY

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -46,6 +46,7 @@ class WatchdogWorkflowTests(unittest.TestCase):
         self.assertIn("uses: google-github-actions/auth@v3", text)
         self.assertIn("workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}", text)
         self.assertIn("service_account: ${{ env.GCP_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}", text)
+        self.assertIn("WATCHDOG_MAX_AGE_SECONDS: ${{ vars.WATCHDOG_MAX_AGE_SECONDS || '1800' }}", text)
 
     def test_watchdog_installs_locked_internal_dependency(self) -> None:
         text = self.workflow_text
@@ -53,6 +54,14 @@ class WatchdogWorkflowTests(unittest.TestCase):
         self.assertIn("qpk_req=\"$(grep -E '^quant-platform-kit @ ' \"$REQ_FILE\")\"", text)
         self.assertIn('python -m pip install "$qpk_req" google-cloud-firestore', text)
         self.assertNotIn("pip install quant-platform-kit google-cloud-firestore", text)
+
+    def test_watchdog_reads_firestore_heartbeat_with_supported_qpk_api(self) -> None:
+        text = self.workflow_text
+
+        self.assertIn("from quant_platform_kit.common.health import HealthMonitor, is_heartbeat_fresh", text)
+        self.assertIn("heartbeat = HealthMonitor().read()", text)
+        self.assertIn("alive = is_heartbeat_fresh(heartbeat, max_age_seconds)", text)
+        self.assertNotIn(".check_alive()", text)
 
     def test_watchdog_qpk_pin_includes_health_module_release(self) -> None:
         requirement = _qpk_requirement(REQUIREMENTS)


### PR DESCRIPTION
## Summary
- read the shared HealthMonitor heartbeat via the supported QPK API instead of calling a non-existent HealthMonitor.check_alive method
- make watchdog freshness configurable with WATCHDOG_MAX_AGE_SECONDS, defaulting to 30 minutes
- extend watchdog workflow tests to guard the supported Firestore heartbeat API path

## Verification
- python3 -m unittest tests.test_watchdog_workflow -v
- uvx ruff check tests/test_watchdog_workflow.py
- git diff --check