### PR TITLE
[codex] relax runtime watchdog freshness window

### DIFF
--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -13,7 +13,7 @@ env:
   GCP_PROJECT_ID: binancequant
   GCP_WORKLOAD_IDENTITY_PROVIDER: projects/677468735457/locations/global/workloadIdentityPools/github-actions/providers/github-main
   GCP_WORKLOAD_IDENTITY_SERVICE_ACCOUNT: binance-platform-runtime@binancequant.iam.gserviceaccount.com
-  WATCHDOG_MAX_AGE_SECONDS: ${{ vars.WATCHDOG_MAX_AGE_SECONDS || '1800' }}
+  WATCHDOG_MAX_AGE_SECONDS: ${{ vars.WATCHDOG_MAX_AGE_SECONDS || '4500' }}
 
 jobs:
   check:
@@ -48,7 +48,7 @@ jobs:
           import os
           from quant_platform_kit.common.health import HealthMonitor, is_heartbeat_fresh
 
-          max_age_seconds = int(os.environ.get("WATCHDOG_MAX_AGE_SECONDS", "1800"))
+          max_age_seconds = int(os.environ.get("WATCHDOG_MAX_AGE_SECONDS", "4500"))
           heartbeat = HealthMonitor().read()
           alive = is_heartbeat_fresh(heartbeat, max_age_seconds)
           if heartbeat is None:

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -46,7 +46,7 @@ class WatchdogWorkflowTests(unittest.TestCase):
         self.assertIn("uses: google-github-actions/auth@v3", text)
         self.assertIn("workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}", text)
         self.assertIn("service_account: ${{ env.GCP_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}", text)
-        self.assertIn("WATCHDOG_MAX_AGE_SECONDS: ${{ vars.WATCHDOG_MAX_AGE_SECONDS || '1800' }}", text)
+        self.assertIn("WATCHDOG_MAX_AGE_SECONDS: ${{ vars.WATCHDOG_MAX_AGE_SECONDS || '4500' }}", text)
 
     def test_watchdog_installs_locked_internal_dependency(self) -> None:
         text = self.workflow_text


### PR DESCRIPTION
## Summary
- increase watchdog default freshness from 30 minutes to 75 minutes
- keep the repository variable override path intact

## Root cause
Runtime dispatches are hourly, but the watchdog default allowed only 30 minutes, so it could fail between healthy hourly runtime cycles.

## Validation
- python3 -m pytest -q tests/test_watchdog_workflow.py
- actionlint .github/workflows/watchdog.yml
- git diff --check
