### PR TITLE
chore: bump qsl compat bundle to 2026.07.1 (phase-2 runtime)

### DIFF
--- a/qsl.toml
+++ b/qsl.toml
@@ -7,8 +7,8 @@ enforce_bundle = false
 migration_mode = "pyproject-uv-poc"
 
 [qsl.requires]
-quant_platform_kit = "6d3675914eb5d3fe072d3212a90dfb55fe1c1df4"
-crypto_strategies = "84e7bf5566167861f7b53bf74261364d055cd30f"
+quant_platform_kit = "7032cde4547e7ec59af15df8935d142461a77051"
+crypto_strategies = "c0203b66746efb63e79f4d4bc9a65758c342817e"
 
 [qsl.compat]
-bundle = "2026.07.0"
+bundle = "2026.07.1"

--- a/qsl.toml
+++ b/qsl.toml
@@ -8,7 +8,7 @@ migration_mode = "pyproject-uv-poc"
 
 [qsl.requires]
 quant_platform_kit = "7032cde4547e7ec59af15df8935d142461a77051"
-crypto_strategies = "3b8b5828725a40c05de08e4829aaf768dcbf20d9"
+crypto_strategies = "64a62781f9194a23548a373c7724e132ef311f1f"
 
 [qsl.compat]
 bundle = "2026.07.1"

--- a/qsl.toml
+++ b/qsl.toml
@@ -8,7 +8,7 @@ migration_mode = "pyproject-uv-poc"
 
 [qsl.requires]
 quant_platform_kit = "7032cde4547e7ec59af15df8935d142461a77051"
-crypto_strategies = "c0203b66746efb63e79f4d4bc9a65758c342817e"
+crypto_strategies = "3b8b5828725a40c05de08e4829aaf768dcbf20d9"
 
 [qsl.compat]
 bundle = "2026.07.1"

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@6d3675914eb5d3fe072d3212a90dfb55fe1c1df4
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@84e7bf5566167861f7b53bf74261364d055cd30f
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@c0203b66746efb63e79f4d4bc9a65758c342817e
 python-binance
 pandas
 numpy

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@3b8b5828725a40c05de08e4829aaf768dcbf20d9
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@64a62781f9194a23548a373c7724e132ef311f1f
 python-binance
 pandas
 numpy

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@c0203b66746efb63e79f4d4bc9a65758c342817e
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@3b8b5828725a40c05de08e4829aaf768dcbf20d9
 python-binance
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@6d3675914eb5d3fe072d3212a90dfb55fe1c1df4
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@84e7bf5566167861f7b53bf74261364d055cd30f
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@c0203b66746efb63e79f4d4bc9a65758c342817e
 python-binance
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@3b8b5828725a40c05de08e4829aaf768dcbf20d9
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@64a62781f9194a23548a373c7724e132ef311f1f
 python-binance
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@c0203b66746efb63e79f4d4bc9a65758c342817e
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@3b8b5828725a40c05de08e4829aaf768dcbf20d9
 python-binance
 pandas
 numpy

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -68,7 +68,7 @@ class WatchdogWorkflowTests(unittest.TestCase):
         lock = _qpk_requirement(LOCK)
 
         self.assertEqual(requirement, lock)
-        self.assertIn("@6d3675914eb5d3fe072d3212a90dfb55fe1c1df4", lock)
+        self.assertIn("@7032cde4547e7ec59af15df8935d142461a77051", lock)
         self.assertNotIn("@86f03fb8e83c0d372f4e1c64cccf3e6da50b8dd4", lock)
 
     def test_crypto_strategies_pin_matches_qpk_health_dependency(self) -> None:
@@ -76,7 +76,7 @@ class WatchdogWorkflowTests(unittest.TestCase):
         lock = _crypto_strategies_requirement(LOCK)
 
         self.assertEqual(requirement, lock)
-        self.assertIn("@84e7bf5566167861f7b53bf74261364d055cd30f", lock)
+        self.assertIn("@3b8b5828725a40c05de08e4829aaf768dcbf20d9", lock)
         self.assertNotIn("@2c152cf", lock)
 
 

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -76,7 +76,7 @@ class WatchdogWorkflowTests(unittest.TestCase):
         lock = _crypto_strategies_requirement(LOCK)
 
         self.assertEqual(requirement, lock)
-        self.assertIn("@3b8b5828725a40c05de08e4829aaf768dcbf20d9", lock)
+        self.assertIn("@64a62781f9194a23548a373c7724e132ef311f1f", lock)
         self.assertNotIn("@2c152cf", lock)
 
 


### PR DESCRIPTION
## Summary
- Update qsl.toml: bump `qsl.compat.bundle` to `2026.07.1`.
- Phase-2 runtime compatibility sweep for QSL warning convergence.
- No functional behavior changes intended.

## Validation
- Verified via \ minimal repo checks in this branch before PR.
-  clean.

## Notes
- If any previously failing tests exist, they are pre-existing unless explicitly introduced in commit cc64d64.