### PR TITLE
[codex] fix runtime combo trend pool default

### DIFF
--- a/strategy_runtime.py
+++ b/strategy_runtime.py
@@ -24,6 +24,7 @@ from trend_pool_support import get_default_live_pool_candidates as tp_get_defaul
 DEFAULT_LOCAL_TREND_POOL_ARTIFACT = Path(__file__).resolve().parent / "artifacts" / "live_pool_legacy.json"
 # Ensure artifacts directory exists so local-fallback path never fails with FileNotFoundError
 DEFAULT_LOCAL_TREND_POOL_ARTIFACT.parent.mkdir(parents=True, exist_ok=True)
+DEFAULT_TREND_POOL_SIZE = 5
 
 
 @dataclass(frozen=True)
@@ -47,7 +48,7 @@ class LoadedStrategyRuntime:
 
     @property
     def trend_pool_size(self) -> int:
-        return int(self.merged_runtime_config["trend_pool_size"])
+        return int(self.merged_runtime_config.get("trend_pool_size", DEFAULT_TREND_POOL_SIZE))
 
     @property
     def artifact_contract(self) -> dict[str, Any]:

--- a/tests/test_strategy_runtime.py
+++ b/tests/test_strategy_runtime.py
@@ -44,6 +44,20 @@ class StrategyRuntimeTests(unittest.TestCase):
         self.assertGreaterEqual(len(runtime.local_artifact_candidates), 1)
         self.assertIn(str(runtime.default_local_artifact_path), runtime.artifact_contract["default_local_candidates"])
 
+    def test_combo_profile_uses_platform_trend_pool_default(self):
+        try:
+            from strategy_runtime import load_strategy_runtime
+        except ModuleNotFoundError as exc:
+            if exc.name == "pandas":
+                self.skipTest("pandas is not installed")
+            raise
+
+        runtime = load_strategy_runtime("crypto_equity_combo")
+
+        self.assertEqual(runtime.profile, "crypto_equity_combo")
+        self.assertNotIn("trend_pool_size", runtime.merged_runtime_config)
+        self.assertEqual(runtime.trend_pool_size, 5)
+
     def test_strategy_runtime_evaluate_returns_decision_with_buy_sell_diagnostics(self):
         try:
             from strategy_runtime import load_strategy_runtime


### PR DESCRIPTION
## Summary
- Add a platform default trend pool size when a strategy manifest does not define `trend_pool_size`.
- Add regression coverage for `crypto_equity_combo`, which currently omits that manifest key.

## Root cause
The Runtime workflow was dispatched with `STRATEGY_PROFILE=crypto_equity_combo`. `main.py` reads `STRATEGY_RUNTIME.trend_pool_size` at import time, but the combo profile manifest does not include `trend_pool_size`, causing `KeyError: 'trend_pool_size'` before the execution report could be written.

## Validation
- `PYTHONPATH="/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src:$PWD" STRATEGY_PROFILE=crypto_equity_combo python3 - <<'PY' ...` -> prints `5`
- `python3 -m py_compile ...`
- `python3 -m unittest discover -s tests -v` -> 111 tests OK
- `python3 -m ruff check --exclude external .`
- `bash tests/test_runtime_workflow_shared_config.sh`
- `git diff --check`