### PR TITLE
[codex] bump crypto strategies for guarded combo

### DIFF
--- a/qsl.toml
+++ b/qsl.toml
@@ -8,7 +8,7 @@ migration_mode = "pyproject-uv-poc"
 
 [qsl.requires]
 quant_platform_kit = "7032cde4547e7ec59af15df8935d142461a77051"
-crypto_strategies = "64a62781f9194a23548a373c7724e132ef311f1f"
+crypto_strategies = "139681bd93b30447a559367c476bd29b7a78b285"
 
 [qsl.compat]
 bundle = "2026.07.1"

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@64a62781f9194a23548a373c7724e132ef311f1f
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@139681bd93b30447a559367c476bd29b7a78b285
 python-binance
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@64a62781f9194a23548a373c7724e132ef311f1f
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@139681bd93b30447a559367c476bd29b7a78b285
 python-binance
 pandas
 numpy

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -76,7 +76,7 @@ class WatchdogWorkflowTests(unittest.TestCase):
         lock = _crypto_strategies_requirement(LOCK)
 
         self.assertEqual(requirement, lock)
-        self.assertIn("@64a62781f9194a23548a373c7724e132ef311f1f", lock)
+        self.assertIn("@139681bd93b30447a559367c476bd29b7a78b285", lock)
         self.assertNotIn("@2c152cf", lock)
 
 


### PR DESCRIPTION
## Summary
- Bump CryptoStrategies to the guarded combo release commit.
- Keep requirements and qsl compatibility metadata aligned.
- Update watchdog pin assertion.

## Test Plan
- `PYTHONPATH=/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src python3 -m pytest -q tests/test_runtime_config_support.py tests/test_strategy_loader.py tests/test_strategy_runtime.py tests/test_notify_i18n.py tests/test_watchdog_workflow.py`
- `python3 -m ruff check .`