### PR TITLE
Force reinstall internal runtime deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,16 @@ jobs:
             return 1
           }
 
+          force_reinstall_internal_git_deps() {
+            local requirement
+            while IFS= read -r requirement; do
+              if [ -n "$requirement" ]; then
+                install_with_retry "Force reinstall internal dependency ${requirement%% @ *}" \
+                  "$VENV_PATH/bin/pip" install --force-reinstall --no-deps "$requirement"
+              fi
+            done < <(grep -E '^(quant-platform-kit|crypto-strategies) @ git\\+' "$REQ_FILE" || true)
+          }
+
           if [ ! -x "$VENV_PATH/bin/python" ]; then
             echo "Creating dependency venv at $VENV_PATH."
             rm -rf "$VENV_PATH"
@@ -110,6 +120,7 @@ jobs:
             echo "$REQ_FILE changed or cache is cold; updating dependency venv."
             install_with_retry "Upgrade pip" "$VENV_PATH/bin/pip" install -U pip
             install_with_retry "Install runtime dependencies" "$VENV_PATH/bin/pip" install -r "$REQ_FILE"
+            force_reinstall_internal_git_deps
             echo "$CURR_HASH" > "$HASH_FILE"
             echo "$CURR_PYTHON_VERSION" > "$PYTHON_VERSION_FILE"
           fi

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "watchdog.yml"
+RUNTIME_WORKFLOW = ROOT / ".github" / "workflows" / "main.yml"
 REQUIREMENTS = ROOT / "requirements.txt"
 LOCK = ROOT / "requirements-lock.txt"
 
@@ -54,6 +55,13 @@ class WatchdogWorkflowTests(unittest.TestCase):
         self.assertIn("qpk_req=\"$(grep -E '^quant-platform-kit @ ' \"$REQ_FILE\")\"", text)
         self.assertIn('python -m pip install "$qpk_req" google-cloud-firestore', text)
         self.assertNotIn("pip install quant-platform-kit google-cloud-firestore", text)
+
+    def test_runtime_workflow_force_reinstalls_internal_git_dependencies(self) -> None:
+        text = RUNTIME_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("force_reinstall_internal_git_deps()", text)
+        self.assertIn("pip\" install --force-reinstall --no-deps \"$requirement\"", text)
+        self.assertIn("grep -E '^(quant-platform-kit|crypto-strategies) @ git\\\\+'", text)
 
     def test_watchdog_reads_firestore_heartbeat_with_supported_qpk_api(self) -> None:
         text = self.workflow_text


### PR DESCRIPTION
## Summary\n- force reinstall internal git direct dependencies during runtime deploy updates\n- cover the runtime workflow guard in tests\n\n## Why\nThe runtime venv can otherwise keep an installed package with the same package version even when the git pin changed, leaving stale code in place.\n\n## Validation\n- PYTHONPATH=/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src:. python3 -m pytest -q tests/test_watchdog_workflow.py\n- python3 -m ruff check .\n- PYTHONPATH=/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src:. python3 -m unittest discover -s tests -v