### PR TITLE
Force internal deps on runtime cache hit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,6 +116,7 @@ jobs:
 
           if [ "$VENV_RECREATED" = "false" ] && [ -f "$HASH_FILE" ] && [ "$CURR_HASH" = "$(cat "$HASH_FILE")" ]; then
             echo "$REQ_FILE unchanged; reusing cached venv."
+            force_reinstall_internal_git_deps
           else
             echo "$REQ_FILE changed or cache is cold; updating dependency venv."
             install_with_retry "Upgrade pip" "$VENV_PATH/bin/pip" install -U pip

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -62,6 +62,8 @@ class WatchdogWorkflowTests(unittest.TestCase):
         self.assertIn("force_reinstall_internal_git_deps()", text)
         self.assertIn("pip\" install --force-reinstall --no-deps \"$requirement\"", text)
         self.assertIn("grep -E '^(quant-platform-kit|crypto-strategies) @ git\\\\+'", text)
+        self.assertIn('"$REQ_FILE unchanged; reusing cached venv."', text)
+        self.assertGreaterEqual(text.count("force_reinstall_internal_git_deps"), 3)
 
     def test_watchdog_reads_firestore_heartbeat_with_supported_qpk_api(self) -> None:
         text = self.workflow_text


### PR DESCRIPTION
## Summary\n- force reinstall internal git direct refs even when the runtime requirements hash is unchanged\n- extend workflow test coverage for cache-hit behavior\n\n## Why\nA workflow-only change can otherwise keep a stale cached venv after the internal package pin was updated in a previous deploy.\n\n## Validation\n- PYTHONPATH=/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src:. python3 -m pytest -q tests/test_watchdog_workflow.py\n- python3 -m ruff check .\n- PYTHONPATH=/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src:. python3 -m unittest discover -s tests -v