### PR TITLE
Fix internal dependency grep pattern

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
                 install_with_retry "Force reinstall internal dependency ${requirement%% @ *}" \
                   "$VENV_PATH/bin/pip" install --force-reinstall --no-deps "$requirement"
               fi
-            done < <(grep -E '^(quant-platform-kit|crypto-strategies) @ git\\+' "$REQ_FILE" || true)
+            done < <(grep -E '^(quant-platform-kit|crypto-strategies) @ git\+' "$REQ_FILE" || true)
           }
 
           if [ ! -x "$VENV_PATH/bin/python" ]; then

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -61,7 +61,7 @@ class WatchdogWorkflowTests(unittest.TestCase):
 
         self.assertIn("force_reinstall_internal_git_deps()", text)
         self.assertIn("pip\" install --force-reinstall --no-deps \"$requirement\"", text)
-        self.assertIn("grep -E '^(quant-platform-kit|crypto-strategies) @ git\\\\+'", text)
+        self.assertIn("grep -E '^(quant-platform-kit|crypto-strategies) @ git\\+'", text)
         self.assertIn('"$REQ_FILE unchanged; reusing cached venv."', text)
         self.assertGreaterEqual(text.count("force_reinstall_internal_git_deps"), 3)
 


### PR DESCRIPTION
## Summary\n- fix runtime workflow grep pattern so internal git direct refs are actually matched\n- keep cache-hit force reinstall coverage aligned\n\n## Validation\n- grep -E '^(quant-platform-kit|crypto-strategies) @ git\+' requirements-lock.txt\n- PYTHONPATH=/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src:. python3 -m pytest -q tests/test_watchdog_workflow.py\n- python3 -m ruff check .