### PR TITLE
Wire combo runtime env overrides

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,16 @@ jobs:
           NOTIFY_LANG: ${{ vars.NOTIFY_LANG }}
           EXECUTION_REPORT_GCS_URI: ${{ vars.EXECUTION_REPORT_GCS_URI }}
           BINANCE_DRY_RUN: ${{ vars.BINANCE_DRY_RUN || 'true' }}
+          BTC_WEIGHT: ${{ vars.BTC_WEIGHT }}
+          TREND_WEIGHT: ${{ vars.TREND_WEIGHT }}
+          DYNAMIC_MODE: ${{ vars.DYNAMIC_MODE }}
+          DYNAMIC_REGIME_OFF_CUT: ${{ vars.DYNAMIC_REGIME_OFF_CUT }}
+          ROTATION_TOP_N: ${{ vars.ROTATION_TOP_N }}
+          TARGET_VOL: ${{ vars.TARGET_VOL }}
+          CIRCUIT_BREAKER_ENABLED: ${{ vars.CIRCUIT_BREAKER_ENABLED }}
+          ZSCORE_EXIT_RISK_REDUCED_EXPOSURE: ${{ vars.ZSCORE_EXIT_RISK_REDUCED_EXPOSURE }}
+          ZSCORE_EXIT_RISK_OFF_EXPOSURE: ${{ vars.ZSCORE_EXIT_RISK_OFF_EXPOSURE }}
+          ZSCORE_EXIT_ALLOW_OUTSIDE_EXECUTION_WINDOW: ${{ vars.ZSCORE_EXIT_ALLOW_OUTSIDE_EXECUTION_WINDOW }}
           VALIDATE_ONLY: ${{ github.event.inputs.validate_only || 'false' }}
 
       - name: 5. Capture execution timestamp

--- a/application/state_service.py
+++ b/application/state_service.py
@@ -43,7 +43,7 @@ def load_cycle_state(
             report,
             gate="trend_buy_paused_degraded_mode",
             category="trend",
-            detail=str(trend_pool_resolution.get("source", "unknown")),
+            detail=str(trend_pool_resolution.get("source_kind") or trend_pool_resolution.get("source", "unknown")),
         )
     return state, trend_pool_resolution, runtime_trend_universe, allow_new_trend_entries
 

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@a830b5dd99d9e7fefa449dde80d7c0c2c80d5fdb
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@6fe378adc6602412a1763ca115b5d17d311a65a9
 python-binance
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@a830b5dd99d9e7fefa449dde80d7c0c2c80d5fdb
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@6fe378adc6602412a1763ca115b5d17d311a65a9
 python-binance
 pandas
 numpy

--- a/strategy_runtime.py
+++ b/strategy_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -25,6 +26,57 @@ DEFAULT_LOCAL_TREND_POOL_ARTIFACT = Path(__file__).resolve().parent / "artifacts
 # Ensure artifacts directory exists so local-fallback path never fails with FileNotFoundError
 DEFAULT_LOCAL_TREND_POOL_ARTIFACT.parent.mkdir(parents=True, exist_ok=True)
 DEFAULT_TREND_POOL_SIZE = 5
+COMBO_RUNTIME_ENV_OVERRIDES: tuple[tuple[str, str, str], ...] = (
+    ("BTC_WEIGHT", "btc_weight", "ratio"),
+    ("TREND_WEIGHT", "trend_weight", "ratio"),
+    ("DYNAMIC_MODE", "dynamic_mode", "bool"),
+    ("DYNAMIC_REGIME_OFF_CUT", "dynamic_regime_off_cut", "ratio"),
+    ("ROTATION_TOP_N", "rotation_top_n", "int"),
+    ("TARGET_VOL", "target_vol", "positive_float"),
+    ("CIRCUIT_BREAKER_ENABLED", "circuit_breaker_enabled", "bool"),
+    ("ZSCORE_EXIT_RISK_REDUCED_EXPOSURE", "zscore_exit_risk_reduced_exposure", "ratio"),
+    ("ZSCORE_EXIT_RISK_OFF_EXPOSURE", "zscore_exit_risk_off_exposure", "ratio"),
+    ("ZSCORE_EXIT_ALLOW_OUTSIDE_EXECUTION_WINDOW", "zscore_exit_allow_outside_execution_window", "bool"),
+)
+
+
+def _parse_env_bool(name: str, raw: str) -> bool:
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "y", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "n", "off"}:
+        return False
+    raise ValueError(f"{name} must be boolean-like")
+
+
+def _parse_runtime_env_value(name: str, raw: str, kind: str) -> Any:
+    if kind == "bool":
+        return _parse_env_bool(name, raw)
+    if kind == "int":
+        value = int(raw)
+        if value < 1:
+            raise ValueError(f"{name} must be >= 1")
+        return value
+    value = float(raw)
+    if kind == "ratio":
+        if not 0.0 <= value <= 1.0:
+            raise ValueError(f"{name} must be between 0 and 1")
+        return value
+    if kind == "positive_float":
+        if value <= 0.0:
+            raise ValueError(f"{name} must be > 0")
+        return value
+    raise ValueError(f"unsupported runtime env parser: {kind}")
+
+
+def _load_combo_runtime_overrides() -> dict[str, Any]:
+    overrides: dict[str, Any] = {}
+    for env_name, config_key, kind in COMBO_RUNTIME_ENV_OVERRIDES:
+        raw = os.getenv(env_name)
+        if raw is None or not raw.strip():
+            continue
+        overrides[config_key] = _parse_runtime_env_value(env_name, raw, kind)
+    return overrides
 
 
 @dataclass(frozen=True)
@@ -216,12 +268,16 @@ def load_strategy_runtime(raw_profile: str | None) -> LoadedStrategyRuntime:
         platform_id=BINANCE_PLATFORM,
     )
     merged_runtime_config = dict(entrypoint.manifest.default_config)
+    runtime_overrides: dict[str, Any] = {}
+    if entrypoint.manifest.profile == "crypto_equity_combo":
+        runtime_overrides.update(_load_combo_runtime_overrides())
     local_artifact_candidates = tuple(
         Path(path) for path in tp_get_default_live_pool_candidates(DEFAULT_LOCAL_TREND_POOL_ARTIFACT)
     )
     return LoadedStrategyRuntime(
         entrypoint=entrypoint,
         runtime_adapter=runtime_adapter,
+        runtime_overrides=runtime_overrides,
         merged_runtime_config=merged_runtime_config,
         local_artifact_candidates=local_artifact_candidates,
     )

--- a/tests/test_strategy_runtime.py
+++ b/tests/test_strategy_runtime.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import types
 import unittest
@@ -57,6 +58,60 @@ class StrategyRuntimeTests(unittest.TestCase):
         self.assertEqual(runtime.profile, "crypto_equity_combo")
         self.assertNotIn("trend_pool_size", runtime.merged_runtime_config)
         self.assertEqual(runtime.trend_pool_size, 5)
+
+    def test_combo_profile_reads_runtime_env_overrides(self):
+        try:
+            from strategy_runtime import load_strategy_runtime
+        except ModuleNotFoundError as exc:
+            if exc.name == "pandas":
+                self.skipTest("pandas is not installed")
+            raise
+
+        with patch.dict(
+            os.environ,
+            {
+                "BTC_WEIGHT": "0.5",
+                "TREND_WEIGHT": "0.5",
+                "DYNAMIC_MODE": "false",
+                "DYNAMIC_REGIME_OFF_CUT": "0.30",
+                "ROTATION_TOP_N": "3",
+                "TARGET_VOL": "0.25",
+                "CIRCUIT_BREAKER_ENABLED": "false",
+                "ZSCORE_EXIT_RISK_REDUCED_EXPOSURE": "0.40",
+                "ZSCORE_EXIT_RISK_OFF_EXPOSURE": "0.20",
+                "ZSCORE_EXIT_ALLOW_OUTSIDE_EXECUTION_WINDOW": "false",
+            },
+            clear=True,
+        ):
+            runtime = load_strategy_runtime("crypto_equity_combo")
+
+        self.assertEqual(
+            runtime.runtime_overrides,
+            {
+                "btc_weight": 0.5,
+                "trend_weight": 0.5,
+                "dynamic_mode": False,
+                "dynamic_regime_off_cut": 0.30,
+                "rotation_top_n": 3,
+                "target_vol": 0.25,
+                "circuit_breaker_enabled": False,
+                "zscore_exit_risk_reduced_exposure": 0.40,
+                "zscore_exit_risk_off_exposure": 0.20,
+                "zscore_exit_allow_outside_execution_window": False,
+            },
+        )
+
+    def test_combo_profile_rejects_invalid_runtime_env_override(self):
+        try:
+            from strategy_runtime import load_strategy_runtime
+        except ModuleNotFoundError as exc:
+            if exc.name == "pandas":
+                self.skipTest("pandas is not installed")
+            raise
+
+        with patch.dict(os.environ, {"BTC_WEIGHT": "1.5"}, clear=True):
+            with self.assertRaisesRegex(ValueError, "BTC_WEIGHT must be between 0 and 1"):
+                load_strategy_runtime("crypto_equity_combo")
 
     def test_combo_profile_exposes_binance_execution_plan(self):
         try:

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -86,7 +86,7 @@ class WatchdogWorkflowTests(unittest.TestCase):
         lock = _crypto_strategies_requirement(LOCK)
 
         self.assertEqual(requirement, lock)
-        self.assertIn("@a830b5dd99d9e7fefa449dde80d7c0c2c80d5fdb", lock)
+        self.assertIn("@6fe378adc6602412a1763ca115b5d17d311a65a9", lock)
         self.assertNotIn("@2c152cf", lock)
 
 


### PR DESCRIPTION
## Summary\n- pin CryptoStrategies to 6fe378a with configurable combo regime cut\n- pass combo GitHub Variables into Runtime workflow and parse them into crypto_equity_combo runtime_config\n- improve degraded trend-pool gate detail to use source_kind\n\n## Validation\n- PYTHONPATH=/Users/lisiyi/Projects/BinancePlatform:/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src python3 -m unittest tests.test_strategy_runtime tests.test_state_service tests.test_watchdog_workflow\n- PYTHONPATH=/Users/lisiyi/Projects/BinancePlatform:/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src python3 -m unittest discover -s tests -p 'test*.py'\n- python3 -m ruff check .\n- actionlint .github/workflows/main.yml\n- git diff --check\n\n## Notes\n- REBALANCE_THRESHOLD is intentionally not mapped to dynamic_regime_off_cut because the existing settings example value 0.05 is not equivalent to regime-off trend cut. Use DYNAMIC_REGIME_OFF_CUT explicitly.