### PR TITLE
Add trend candidate filter diagnostics

### DIFF
--- a/application/execution_service.py
+++ b/application/execution_service.py
@@ -5,6 +5,95 @@ from __future__ import annotations
 from runtime_support import record_gating_event
 
 
+def _safe_float(value, default=0.0):
+    try:
+        return float(value)
+    except Exception:
+        return float(default)
+
+
+def _is_missing(value) -> bool:
+    if value is None:
+        return True
+    try:
+        return value != value
+    except Exception:
+        return False
+
+
+def build_trend_candidate_filter_diagnostics(
+    active_trend_pool,
+    trend_indicators,
+    btc_snapshot,
+    prices,
+):
+    diagnostics = {}
+    btc_regime_on = bool(btc_snapshot.get("regime_on", True))
+    btc_required = ("btc_roc20", "btc_roc60", "btc_roc120")
+    missing_btc_fields = [field for field in btc_required if _is_missing(btc_snapshot.get(field))]
+    for symbol in active_trend_pool:
+        symbol = str(symbol)
+        reasons = []
+        indicators = trend_indicators.get(symbol)
+        if not btc_regime_on:
+            reasons.append("btc_regime_off")
+        if missing_btc_fields:
+            reasons.append("missing_btc_momentum")
+        if not isinstance(indicators, dict):
+            diagnostics[symbol] = {"reasons": reasons + ["missing_indicators"]}
+            continue
+
+        required_fields = ("sma20", "sma60", "sma200", "roc20", "roc60", "roc120", "vol20")
+        missing_fields = [field for field in required_fields if _is_missing(indicators.get(field))]
+        if missing_fields:
+            reasons.append("missing_fields:" + ",".join(missing_fields))
+
+        raw_price = prices.get(symbol)
+        if _is_missing(raw_price):
+            reasons.append("missing_price")
+            diagnostics[symbol] = {"reasons": reasons}
+            continue
+
+        price = _safe_float(raw_price)
+        for field in ("sma20", "sma60", "sma200"):
+            value = indicators.get(field)
+            if not _is_missing(value) and price <= _safe_float(value):
+                reasons.append(f"price_lte_{field}")
+
+        vol20 = _safe_float(indicators.get("vol20"))
+        if not _is_missing(indicators.get("vol20")) and vol20 <= 0:
+            reasons.append("vol20_lte_zero")
+
+        relative_score = None
+        abs_momentum = None
+        if (
+            not missing_btc_fields
+            and not any(_is_missing(indicators.get(field)) for field in ("roc20", "roc60", "roc120", "vol20"))
+            and vol20 > 0
+        ):
+            rel_20 = _safe_float(indicators.get("roc20")) - _safe_float(btc_snapshot.get("btc_roc20"))
+            rel_60 = _safe_float(indicators.get("roc60")) - _safe_float(btc_snapshot.get("btc_roc60"))
+            rel_120 = _safe_float(indicators.get("roc120")) - _safe_float(btc_snapshot.get("btc_roc120"))
+            abs_momentum = (
+                0.5 * _safe_float(indicators.get("roc20"))
+                + 0.3 * _safe_float(indicators.get("roc60"))
+                + 0.2 * _safe_float(indicators.get("roc120"))
+            )
+            relative_score = (0.5 * rel_20 + 0.3 * rel_60 + 0.2 * rel_120) / vol20
+            if relative_score <= 0:
+                reasons.append("relative_score_lte_zero")
+            if abs_momentum <= 0:
+                reasons.append("abs_momentum_lte_zero")
+
+        payload = {"reasons": reasons or ["unknown_filter"]}
+        if relative_score is not None:
+            payload["relative_score"] = round(float(relative_score), 6)
+        if abs_momentum is not None:
+            payload["abs_momentum"] = round(float(abs_momentum), 6)
+        diagnostics[symbol] = payload
+    return diagnostics
+
+
 def run_daily_circuit_breaker(
     runtime,
     report,
@@ -361,7 +450,15 @@ def execute_trend_rotation(
             report,
             gate="trend_no_selected_candidate",
             category="trend",
-            detail={"active_trend_pool_size": len(active_trend_pool)},
+            detail={
+                "active_trend_pool_size": len(active_trend_pool),
+                "candidate_filter_reasons": build_trend_candidate_filter_diagnostics(
+                    active_trend_pool,
+                    trend_indicators,
+                    btc_snapshot,
+                    prices,
+                ),
+            },
         )
 
     append_rotation_summary(

--- a/tests/test_execution_service.py
+++ b/tests/test_execution_service.py
@@ -271,6 +271,76 @@ class ExecutionServiceTests(unittest.TestCase):
         self.assertTrue(observed["status_called"])
         self.assertEqual(observed["buy_plan"], {"ETHUSDT": 320.0})
 
+    def test_execute_trend_rotation_records_candidate_filter_reasons(self):
+        runtime = SimpleNamespace(now_utc="2026-03-29T00:00:00Z")
+        report = {"selected_symbols": {"active_trend_pool": [], "selected_candidates": []}, "gating_summary": {}, "gating_events": []}
+        state = {}
+        runtime_trend_universe = {"ETHUSDT": {"base_asset": "ETH"}}
+        trend_indicators = {
+            "ETHUSDT": {
+                "sma20": 2100.0,
+                "sma60": 1900.0,
+                "sma200": 1700.0,
+                "roc20": 0.02,
+                "roc60": 0.04,
+                "roc120": 0.08,
+                "vol20": 0.5,
+            }
+        }
+        btc_snapshot = {"regime_on": True, "btc_roc20": 0.10, "btc_roc60": 0.08, "btc_roc120": 0.06}
+        plans = [
+            {
+                "active_trend_pool": ["ETHUSDT"],
+                "selected_candidates": {},
+                "eligible_buy_symbols": [],
+                "planned_trend_buys": {},
+                "sell_reasons": {},
+            },
+            {
+                "active_trend_pool": ["ETHUSDT"],
+                "selected_candidates": {},
+                "eligible_buy_symbols": [],
+                "planned_trend_buys": {},
+                "sell_reasons": {},
+            },
+        ]
+        observed = {"plan_calls": 0}
+
+        def fake_resolve_strategy_plan(*_args, **_kwargs):
+            plan = plans[observed["plan_calls"]]
+            observed["plan_calls"] += 1
+            return plan
+
+        result = execute_trend_rotation(
+            runtime,
+            report,
+            state,
+            runtime_trend_universe,
+            trend_indicators,
+            btc_snapshot,
+            {"ETHUSDT": 2000.0},
+            {"ETHUSDT": 0.0},
+            1000.0,
+            15.0,
+            [],
+            "20260329",
+            True,
+            True,
+            resolve_strategy_plan=fake_resolve_strategy_plan,
+            append_rotation_summary=lambda *_args: None,
+            execute_trend_sells=lambda *_args: 1000.0,
+            execute_trend_buys=lambda *_args: 1000.0,
+            append_trend_symbol_status=lambda *_args: None,
+            official_trend_pool_symbols=["ETHUSDT"],
+        )
+
+        self.assertEqual(result, 1000.0)
+        detail = report["gating_events"][0]["detail"]
+        self.assertEqual(detail["active_trend_pool_size"], 1)
+        reasons = detail["candidate_filter_reasons"]["ETHUSDT"]["reasons"]
+        self.assertIn("price_lte_sma20", reasons)
+        self.assertIn("relative_score_lte_zero", reasons)
+
     def test_execute_btc_dca_cycle_executes_buy_branch(self):
         runtime = SimpleNamespace(client=object())
         report = {"btc_dca_intents": [], "gating_summary": {}, "gating_events": []}


### PR DESCRIPTION
## Summary\n- add per-symbol filter reasons when the trend pool has symbols but no selected candidate\n- include relative_score/abs_momentum when computable for dry-run/report debugging\n\n## Validation\n- PYTHONPATH=/Users/lisiyi/Projects/BinancePlatform:/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src python3 -m unittest tests.test_execution_service\n- PYTHONPATH=/Users/lisiyi/Projects/BinancePlatform:/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src python3 -m unittest discover -s tests -p 'test*.py'\n- python3 -m ruff check application/execution_service.py tests/test_execution_service.py\n- git diff --check\n\n## Notes\nNo trading behavior changes; this only enriches gating diagnostics.