### PR TITLE
Expose combo regime diagnostics in runtime reports

### DIFF
--- a/application/execution_service.py
+++ b/application/execution_service.py
@@ -443,6 +443,9 @@ def execute_trend_rotation(
     active_trend_pool = list(strategy_plan["active_trend_pool"])
     selected_candidates = dict(strategy_plan["selected_candidates"])
     sell_reasons = dict(strategy_plan["sell_reasons"])
+    combo_diagnostics = dict(strategy_plan.get("combo_diagnostics", {}))
+    if combo_diagnostics:
+        report.setdefault("diagnostics", {})["combo"] = combo_diagnostics
     report["selected_symbols"]["active_trend_pool"] = list(active_trend_pool)
     report["selected_symbols"]["selected_candidates"] = list(selected_candidates.keys())
     if not selected_candidates:

--- a/decision_mapper.py
+++ b/decision_mapper.py
@@ -50,6 +50,8 @@ def map_strategy_decision_to_allocation(
 
 def map_strategy_decision_to_rotation_plan(decision: StrategyDecision) -> dict[str, Any]:
     diagnostics = dict(decision.diagnostics)
+    metadata = diagnostics.get("metadata") if isinstance(diagnostics.get("metadata"), Mapping) else {}
+    combo_meta = metadata.get("combo") if isinstance(metadata.get("combo"), Mapping) else {}
     selected_candidates = {
         str(symbol): {
             "weight": float(payload.get("weight", 0.0)),
@@ -78,4 +80,16 @@ def map_strategy_decision_to_rotation_plan(decision: StrategyDecision) -> dict[s
         "rotation_pool_last_month": diagnostics.get("rotation_pool_last_month"),
         "artifact_contract": dict(diagnostics.get("artifact_contract", {})),
         "risk_flags": tuple(str(flag) for flag in decision.risk_flags),
+        "combo_diagnostics": {
+            "base_btc_weight": float(combo_meta.get("base_btc_weight", 0.0) or 0.0),
+            "base_trend_weight": float(combo_meta.get("base_trend_weight", 0.0) or 0.0),
+            "effective_btc_weight": float(combo_meta.get("btc_weight", 0.0) or 0.0),
+            "effective_trend_weight": float(combo_meta.get("trend_weight", 0.0) or 0.0),
+            "dynamic_regime_mode": str(combo_meta.get("dynamic_regime_mode", "")),
+            "regime_tier": str(combo_meta.get("regime_tier", "")),
+            "regime_off": bool(metadata.get("regime_off", False)),
+            "btc_sma200_ratio": metadata.get("btc_sma200_ratio"),
+            "ma200_slope": metadata.get("ma200_slope"),
+            "gross_exposure": float(metadata.get("gross_exposure", 0.0) or 0.0),
+        },
     }

--- a/tests/test_decision_mapper.py
+++ b/tests/test_decision_mapper.py
@@ -52,6 +52,20 @@ class DecisionMapperTests(unittest.TestCase):
         decision = StrategyDecision(
             diagnostics={
                 "trend_pool": ("ETHUSDT", "SOLUSDT"),
+                "metadata": {
+                    "combo": {
+                        "base_btc_weight": 0.50,
+                        "base_trend_weight": 0.50,
+                        "btc_weight": 0.25,
+                        "trend_weight": 0.0,
+                        "dynamic_regime_mode": "dual_leg",
+                        "regime_tier": "hard",
+                    },
+                    "regime_off": True,
+                    "btc_sma200_ratio": 0.94,
+                    "ma200_slope": -0.01,
+                    "gross_exposure": 0.25,
+                },
                 "rotation_candidates": {
                     "ETHUSDT": {"weight": 0.6, "relative_score": 1.2, "abs_momentum": 0.3},
                 },
@@ -71,6 +85,21 @@ class DecisionMapperTests(unittest.TestCase):
         self.assertEqual(plan["sell_reasons"], {"SOLUSDT": "trend_sell_reason_rotated_out"})
         self.assertEqual(plan["artifact_contract"], {"version": "v1"})
         self.assertEqual(plan["risk_flags"], ("regime_off",))
+        self.assertEqual(
+            plan["combo_diagnostics"],
+            {
+                "base_btc_weight": 0.50,
+                "base_trend_weight": 0.50,
+                "effective_btc_weight": 0.25,
+                "effective_trend_weight": 0.0,
+                "dynamic_regime_mode": "dual_leg",
+                "regime_tier": "hard",
+                "regime_off": True,
+                "btc_sma200_ratio": 0.94,
+                "ma200_slope": -0.01,
+                "gross_exposure": 0.25,
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_execution_service.py
+++ b/tests/test_execution_service.py
@@ -209,6 +209,7 @@ class ExecutionServiceTests(unittest.TestCase):
             {
                 "active_trend_pool": ["ETHUSDT"],
                 "selected_candidates": {"ETHUSDT": {"weight": 1.0, "relative_score": 1.5}},
+                "combo_diagnostics": {"regime_tier": "hard", "effective_btc_weight": 0.25},
                 "eligible_buy_symbols": [],
                 "planned_trend_buys": {},
                 "sell_reasons": {"ETHUSDT": "rotated_out"},
@@ -270,6 +271,8 @@ class ExecutionServiceTests(unittest.TestCase):
         self.assertTrue(observed["sell_called"])
         self.assertTrue(observed["status_called"])
         self.assertEqual(observed["buy_plan"], {"ETHUSDT": 320.0})
+        self.assertEqual(report["diagnostics"]["combo"]["regime_tier"], "hard")
+        self.assertAlmostEqual(report["diagnostics"]["combo"]["effective_btc_weight"], 0.25)
 
     def test_execute_trend_rotation_records_candidate_filter_reasons(self):
         runtime = SimpleNamespace(now_utc="2026-03-29T00:00:00Z")


### PR DESCRIPTION
## Summary
- include combo regime/weight diagnostics in mapped rotation plans
- persist combo diagnostics under execution report diagnostics.combo
- add regression coverage for decision mapping and report output

## Validation
- PYTHONPATH=/Users/lisiyi/Projects/BinancePlatform:/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src python3 -m unittest discover -s tests -p 'test*.py'
- python3 -m ruff check .
- git diff --check