### PR TITLE
[codex] Fix combo bot display name

### DIFF
--- a/main.py
+++ b/main.py
@@ -535,9 +535,10 @@ def maybe_send_periodic_btc_status_report(
     strategy_display_name=None,
     notifier_fn=None,
 ):
+    runtime_manifest = getattr(getattr(STRATEGY_RUNTIME, "entrypoint", None), "manifest", None)
     resolved_strategy_display_name = strategy_display_name or build_strategy_display_name(t)(
         getattr(STRATEGY_RUNTIME, "profile", "crypto_live_pool_rotation"),
-        fallback_name="Crypto Live Pool Rotation",
+        fallback_name=getattr(runtime_manifest, "display_name", "Crypto Live Pool Rotation"),
     )
     return report_maybe_send_periodic_btc_status_report(
         state,

--- a/notify_i18n_support.py
+++ b/notify_i18n_support.py
@@ -132,6 +132,7 @@ _TEXTS = {
         "btc_unavailable_for_dca_sell": "BTC unavailable for DCA sell",
         "strategy_name_crypto_leader_rotation": "Crypto Leader Rotation",
         "strategy_name_crypto_live_pool_rotation": "Crypto Live Pool Rotation",
+        "strategy_name_crypto_equity_combo": "Crypto Equity Combo",
     },
     "zh": {
         "rebalance_title": "🔔 加密调仓",
@@ -258,6 +259,7 @@ _TEXTS = {
         "btc_unavailable_for_dca_sell": "BTC 不足，无法执行定投止盈卖出",
         "strategy_name_crypto_leader_rotation": "加密领涨轮动",
         "strategy_name_crypto_live_pool_rotation": "加密实时池轮动",
+        "strategy_name_crypto_equity_combo": "加密动量组合",
     },
 }
 

--- a/tests/test_notify_i18n.py
+++ b/tests/test_notify_i18n.py
@@ -99,6 +99,14 @@ class NotifyI18nTests(unittest.TestCase):
 
         self.assertEqual(display_name, "加密领涨轮动")
 
+    def test_combo_strategy_profile_uses_chinese_display_name(self):
+        display_name = build_strategy_display_name(build_translator("zh"))(
+            "crypto_equity_combo",
+            fallback_name="Crypto Equity Combo",
+        )
+
+        self.assertEqual(display_name, "加密动量组合")
+
     def test_periodic_btc_status_report_uses_chinese_when_notify_lang_is_zh(self):
         state = {}
         messages = []
@@ -132,6 +140,44 @@ class NotifyI18nTests(unittest.TestCase):
         self.assertIn("💰 总净值", messages[0])
         self.assertIn("₿ BTC 价格", messages[0])
         self.assertIn("AHR999 偏低", messages[0])
+
+    def test_periodic_btc_status_report_uses_combo_display_name(self):
+        state = {}
+        messages = []
+        runtime = SimpleNamespace(
+            profile="crypto_equity_combo",
+            entrypoint=SimpleNamespace(
+                manifest=SimpleNamespace(display_name="Crypto Equity Combo"),
+            ),
+        )
+
+        with patch.dict(os.environ, {"NOTIFY_LANG": "zh"}, clear=False):
+            with patch.object(main, "STRATEGY_RUNTIME", runtime):
+                main.maybe_send_periodic_btc_status_report(
+                    state,
+                    tg_token="",
+                    tg_chat_id="",
+                    now_utc=SimpleNamespace(
+                        hour=0,
+                        strftime=lambda fmt: "2026032700",
+                    ),
+                    interval_hours=24,
+                    total_equity=12500.0,
+                    trend_holdings_equity=3200.0,
+                    trend_daily_pnl=0.0125,
+                    btc_price=87000.0,
+                    btc_snapshot={
+                        "ahr999": 0.7,
+                        "zscore": 1.2,
+                        "sell_trigger": 3.0,
+                        "regime_on": True,
+                    },
+                    btc_target_ratio=0.285,
+                    notifier_fn=messages.append,
+                )
+
+        self.assertEqual(len(messages), 1)
+        self.assertIn("🧭 策略: 加密动量组合", messages[0])
 
     def test_trend_pool_source_logs_use_chinese_when_notify_lang_is_zh(self):
         with patch.dict(os.environ, {"NOTIFY_LANG": "zh"}, clear=False):


### PR DESCRIPTION
## Summary
- fix periodic bot status fallback for `crypto_equity_combo`
- add English/Chinese display name translations for combo profile
- cover combo heartbeat display name with regression tests

## Root cause
`main.maybe_send_periodic_btc_status_report()` resolved the default status strategy name with a hard-coded `Crypto Live Pool Rotation` fallback when no display name was passed. The combo profile also lacked legacy i18n keys, so direct heartbeat calls could show the old/default strategy name.

## Validation
- `PYTHONPATH=/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src:. STRATEGY_PROFILE=crypto_equity_combo NOTIFY_LANG=zh python3 - <<'PY' ... PY` -> `🧭 策略: 加密动量组合`
- `PYTHONPATH=/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src:. python3 -m pytest tests/test_notify_i18n.py tests/test_status_reports.py tests/test_runtime_config_support.py -q` -> 22 passed
- `PYTHONPATH=/Users/lisiyi/Projects/QuantPlatformKit/src:/Users/lisiyi/Projects/CryptoStrategies/src:. python3 -m pytest tests/test_strategy_runtime.py tests/test_cycle_service.py tests/test_runtime_support.py -q` -> 18 passed
- `git diff --check`
