### PR TITLE
chore: align QSL bundle pins

### DIFF
--- a/qsl.toml
+++ b/qsl.toml
@@ -8,8 +8,8 @@ enforce_bundle = false
 migration_mode = "pyproject-uv-poc"
 
 [qsl.requires]
-quant_platform_kit = "7032cde4547e7ec59af15df8935d142461a77051"
-crypto_strategies = "a830b5dd99d9e7fefa449dde80d7c0c2c80d5fdb"
+quant_platform_kit = "37c81901160c5b31127a27dba1c63944933fb6bf"
+crypto_strategies = "746440683f63c3f696a12278aff9c7af030700c2"
 
 [qsl.compat]
-bundle = "2026.07.1"
+bundle = "2026.07.2"

--- a/qsl.toml
+++ b/qsl.toml
@@ -9,7 +9,7 @@ migration_mode = "pyproject-uv-poc"
 
 [qsl.requires]
 quant_platform_kit = "37c81901160c5b31127a27dba1c63944933fb6bf"
-crypto_strategies = "746440683f63c3f696a12278aff9c7af030700c2"
+crypto_strategies = "39bf4733cef922bdeacfd0adef394e7819a04908"
 
 [qsl.compat]
 bundle = "2026.07.2"

--- a/qsl.toml
+++ b/qsl.toml
@@ -3,6 +3,7 @@ repo = "BinancePlatform"
 tier = "runtime-platform"
 ring = 3
 allow_legacy = true
+legacy_reason = "requirements files remain for runtime deployment compatibility during pyproject/uv migration."
 enforce_bundle = false
 migration_mode = "pyproject-uv-poc"
 

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@64a62781f9194a23548a373c7724e132ef311f1f
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@37c81901160c5b31127a27dba1c63944933fb6bf
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@746440683f63c3f696a12278aff9c7af030700c2
 python-binance
 pandas
 numpy

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@746440683f63c3f696a12278aff9c7af030700c2
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@64a62781f9194a23548a373c7724e132ef311f1f
 python-binance
 pandas
 numpy

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@37c81901160c5b31127a27dba1c63944933fb6bf
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@746440683f63c3f696a12278aff9c7af030700c2
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@39bf4733cef922bdeacfd0adef394e7819a04908
 python-binance
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@64a62781f9194a23548a373c7724e132ef311f1f
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@37c81901160c5b31127a27dba1c63944933fb6bf
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@746440683f63c3f696a12278aff9c7af030700c2
 python-binance
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@7032cde4547e7ec59af15df8935d142461a77051
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@746440683f63c3f696a12278aff9c7af030700c2
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@64a62781f9194a23548a373c7724e132ef311f1f
 python-binance
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@37c81901160c5b31127a27dba1c63944933fb6bf
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@746440683f63c3f696a12278aff9c7af030700c2
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@39bf4733cef922bdeacfd0adef394e7819a04908
 python-binance
 pandas
 numpy

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -93,7 +93,7 @@ class WatchdogWorkflowTests(unittest.TestCase):
         lock = _qpk_requirement(LOCK)
 
         self.assertEqual(requirement, lock)
-        self.assertIn("@7032cde4547e7ec59af15df8935d142461a77051", lock)
+        self.assertIn("@37c81901160c5b31127a27dba1c63944933fb6bf", lock)
         self.assertNotIn("@86f03fb8e83c0d372f4e1c64cccf3e6da50b8dd4", lock)
 
     def test_crypto_strategies_pin_matches_qpk_health_dependency(self) -> None:
@@ -101,7 +101,7 @@ class WatchdogWorkflowTests(unittest.TestCase):
         lock = _crypto_strategies_requirement(LOCK)
 
         self.assertEqual(requirement, lock)
-        self.assertIn("@746440683f63c3f696a12278aff9c7af030700c2", lock)
+        self.assertIn("@39bf4733cef922bdeacfd0adef394e7819a04908", lock)
         self.assertNotIn("@2c152cf", lock)
 
 


### PR DESCRIPTION
## Summary
- align this repository with QSL bundle 2026.07.1
- update internal git dependency pins only; no business logic changes

## Validation
- git diff --check
- QuantRuntimeSettings scripts/check_qsl_compat.py reports ok=true for this repo
- QuantRuntimeSettings qslctl report reports 0 strict / 0 warnings across 25 local Quant repos