### PR TITLE
chore(deps): align QPK and CryptoStrategies pins to org baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,14 @@ jobs:
       - name: Check QPK pin and requirements consistency
         run: |
           set -euo pipefail
-          python external/QuantPlatformKit/scripts/check_qpk_pin_consistency.py \
+          mkdir -p /tmp/qpk-pin-guard
+          curl -fsSL -o /tmp/qpk-pin-guard/QPK_PIN \
+            https://raw.githubusercontent.com/QuantStrategyLab/QuantPlatformKit/main/QPK_PIN
+          curl -fsSL -o /tmp/qpk-pin-guard/check_qpk_pin_consistency.py \
+            https://raw.githubusercontent.com/QuantStrategyLab/QuantPlatformKit/main/scripts/check_qpk_pin_consistency.py
+          python /tmp/qpk-pin-guard/check_qpk_pin_consistency.py \
             --root . \
-            --pin-file external/QuantPlatformKit/QPK_PIN
+            --pin-file /tmp/qpk-pin-guard/QPK_PIN
           cmp -s requirements.txt requirements-lock.txt
 
       - name: Run unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,5 +92,13 @@ jobs:
       - name: Run ruff
         run: ruff check --exclude external .
 
+      - name: Check QPK pin and requirements consistency
+        run: |
+          set -euo pipefail
+          python external/QuantPlatformKit/scripts/check_qpk_pin_consistency.py \
+            --root . \
+            --pin-file external/QuantPlatformKit/QPK_PIN
+          cmp -s requirements.txt requirements-lock.txt
+
       - name: Run unit tests
         run: python -m unittest discover -s tests -v

--- a/qsl.toml
+++ b/qsl.toml
@@ -11,8 +11,8 @@ next_action = "complete pyproject/uv migration and restore enforce_bundle=true"
 migration_mode = "pyproject-uv-poc"
 
 [qsl.requires]
-quant_platform_kit = "37c81901160c5b31127a27dba1c63944933fb6bf"
-crypto_strategies = "39bf4733cef922bdeacfd0adef394e7819a04908"
+quant_platform_kit = "8378e939d9324ea63a0f45c9f21ba0e2eeb1cfff"
+crypto_strategies = "ef78312d7653095f585c4f75d45bf765bedc2751"
 
 [qsl.compat]
 bundle = "2026.07.2"

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,5 +1,5 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@0af622ac9d47f7ef93f9379f9ded314c27a344ff
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@eb7bf665c5199f7f075af61ef5c86171eea1f057
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@8378e939d9324ea63a0f45c9f21ba0e2eeb1cfff
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@ef78312d7653095f585c4f75d45bf765bedc2751
 python-binance
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@0af622ac9d47f7ef93f9379f9ded314c27a344ff
-crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@eb7bf665c5199f7f075af61ef5c86171eea1f057
+quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@8378e939d9324ea63a0f45c9f21ba0e2eeb1cfff
+crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@ef78312d7653095f585c4f75d45bf765bedc2751
 python-binance
 pandas
 numpy

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -93,16 +93,16 @@ class WatchdogWorkflowTests(unittest.TestCase):
         lock = _qpk_requirement(LOCK)
 
         self.assertEqual(requirement, lock)
-        self.assertIn("@0af622ac9d47f7ef93f9379f9ded314c27a344ff", lock)
-        self.assertNotIn("@37c81901160c5b31127a27dba1c63944933fb6bf", lock)
+        self.assertIn("@8378e939d9324ea63a0f45c9f21ba0e2eeb1cfff", lock)
+        self.assertNotIn("@0af622ac9d47f7ef93f9379f9ded314c27a344ff", lock)
 
     def test_crypto_strategies_pin_matches_qpk_health_dependency(self) -> None:
         requirement = _crypto_strategies_requirement(REQUIREMENTS)
         lock = _crypto_strategies_requirement(LOCK)
 
         self.assertEqual(requirement, lock)
-        self.assertIn("@eb7bf665c5199f7f075af61ef5c86171eea1f057", lock)
-        self.assertNotIn("@af4df02f88177f0f80e4eab7d1ee04a27283159f", lock)
+        self.assertIn("@ef78312d7653095f585c4f75d45bf765bedc2751", lock)
+        self.assertNotIn("@eb7bf665c5199f7f075af61ef5c86171eea1f057", lock)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `requirements.txt` / `requirements-lock.txt`：QPK → `8378e93`，CryptoStrategies → `ef78312`
- 同步 `qsl.toml` 内部 pin 快照
- CI 新增 QPK pin 检查 + `requirements.txt`/`requirements-lock.txt` 一致性校验

## Test plan
- [ ] CI test job 转绿
- [ ] 合并后 QRS matrix `--sync` 更新 Binance 条目


Made with [Cursor](https://cursor.com)