### PR TITLE
chore(deps): align QPK pin to 53b2ca73a5a5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "QuantStrategyLab platform layer for Binance exchange."
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@8378e939d9324ea63a0f45c9f21ba0e2eeb1cfff",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@53b2ca73a5a50257b5d1a3c769b75c40924e4ba6",
   "crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@ef78312d7653095f585c4f75d45bf765bedc2751",
   "python-binance",
   "pandas",

--- a/qsl.toml
+++ b/qsl.toml
@@ -9,7 +9,7 @@ expires_at = "2026-09-30"
 next_action = "keep uv.lock current and maintain QPK/CryptoStrategies pin consistency"
 
 [qsl.requires]
-quant_platform_kit = "8378e939d9324ea63a0f45c9f21ba0e2eeb1cfff"
+quant_platform_kit = "53b2ca73a5a50257b5d1a3c769b75c40924e4ba6"
 crypto_strategies = "ef78312d7653095f585c4f75d45bf765bedc2751"
 
 [qsl.compat]

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -91,8 +91,8 @@ class WatchdogWorkflowTests(unittest.TestCase):
         requirement = _dependency("quant-platform-kit @ ")
         lock = LOCK.read_text(encoding="utf-8")
 
-        self.assertIn("QuantPlatformKit.git?rev=8378e939d9324ea63a0f45c9f21ba0e2eeb1cfff", lock)
-        self.assertIn("@8378e939d9324ea63a0f45c9f21ba0e2eeb1cfff", requirement)
+        self.assertIn("QuantPlatformKit.git?rev=53b2ca73a5a50257b5d1a3c769b75c40924e4ba6", lock)
+        self.assertIn("@53b2ca73a5a50257b5d1a3c769b75c40924e4ba6", requirement)
         self.assertNotIn("@0af622ac9d47f7ef93f9379f9ded314c27a344ff", lock)
 
     def test_crypto_strategies_pin_matches_qpk_health_dependency(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -211,7 +211,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "python-binance" },
-    { name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=8378e939d9324ea63a0f45c9f21ba0e2eeb1cfff" },
+    { name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=53b2ca73a5a50257b5d1a3c769b75c40924e4ba6" },
     { name = "requests" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.12" },
 ]
@@ -1614,7 +1614,7 @@ wheels = [
 [[package]]
 name = "quant-platform-kit"
 version = "0.10.0"
-source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=8378e939d9324ea63a0f45c9f21ba0e2eeb1cfff#8378e939d9324ea63a0f45c9f21ba0e2eeb1cfff" }
+source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=53b2ca73a5a50257b5d1a3c769b75c40924e4ba6#53b2ca73a5a50257b5d1a3c769b75c40924e4ba6" }
 
 [[package]]
 name = "regex"


### PR DESCRIPTION
## Summary
- 将 QPK pin 对齐到 `53b2ca73a5a5`（含 task 5 live_return_collector）
- 若存在 `uv.lock` 同步刷新

## Test plan
- [ ] Repo CI 转绿

Made with [Cursor](https://cursor.com)