### PR TITLE
feat(risk): stamp consecutive_losses before strategy evaluate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "QuantStrategyLab platform layer for Binance exchange."
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@53b2ca73a5a50257b5d1a3c769b75c40924e4ba6",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@69a0256934d081b5ef309a885384b9eb9f62cf90",
   "crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@ef78312d7653095f585c4f75d45bf765bedc2751",
   "python-binance",
   "pandas",

--- a/qsl.toml
+++ b/qsl.toml
@@ -9,7 +9,7 @@ expires_at = "2026-09-30"
 next_action = "keep uv.lock current and maintain QPK/CryptoStrategies pin consistency"
 
 [qsl.requires]
-quant_platform_kit = "53b2ca73a5a50257b5d1a3c769b75c40924e4ba6"
+quant_platform_kit = "69a0256934d081b5ef309a885384b9eb9f62cf90"
 crypto_strategies = "ef78312d7653095f585c4f75d45bf765bedc2751"
 
 [qsl.compat]

--- a/strategy_runtime.py
+++ b/strategy_runtime.py
@@ -236,6 +236,14 @@ class LoadedStrategyRuntime:
             trend_universe_symbols=tuple(trend_universe_symbols),
             as_of=runtime_now,
         )
+        from quant_platform_kit.strategy_lifecycle.live_equity import stamp_consecutive_losses_on_snapshot
+
+        portfolio_snapshot = stamp_consecutive_losses_on_snapshot(
+            portfolio_snapshot,
+            strategy_profile=self.profile,
+            domain="crypto",
+            logger=getattr(self, "logger", None),
+        )
         evaluation_inputs = build_strategy_evaluation_inputs(
             available_inputs=self.runtime_adapter.available_inputs,
             market_inputs={

--- a/tests/test_strategy_runtime.py
+++ b/tests/test_strategy_runtime.py
@@ -245,6 +245,81 @@ class StrategyRuntimeTests(unittest.TestCase):
         self.assertEqual(ctx.portfolio.metadata["account_metrics"]["cash_usdt"], 2000.0)
         self.assertEqual(evaluation.metadata["strategy_display_name"], "Crypto Live Pool Rotation")
 
+    def test_evaluate_stamps_consecutive_losses(self):
+        import strategy_runtime as strategy_runtime_module
+        from quant_platform_kit.strategy_contracts import StrategyDecision
+
+        class FakeEntrypoint:
+            manifest = StrategyManifest(
+                profile="crypto_live_pool_rotation",
+                domain="crypto",
+                display_name="Crypto Live Pool Rotation",
+                description="test",
+                required_inputs=frozenset(
+                    {
+                        "market_prices",
+                        "derived_indicators",
+                        "benchmark_snapshot",
+                        "portfolio_snapshot",
+                        "universe_snapshot",
+                    }
+                ),
+                default_config={},
+            )
+
+            def evaluate(self, ctx):
+                self.ctx = ctx
+                return StrategyDecision()
+
+        entrypoint = FakeEntrypoint()
+        runtime = strategy_runtime_module.LoadedStrategyRuntime(
+            entrypoint=entrypoint,
+            runtime_adapter=StrategyRuntimeAdapter(
+                available_inputs=frozenset(entrypoint.manifest.required_inputs),
+                portfolio_input_name="portfolio_snapshot",
+            ),
+            merged_runtime_config=FakeEntrypoint.manifest.default_config,
+        )
+        stamped_meta = {"consecutive_losses": 5}
+
+        def _stamp(snapshot, **_kwargs):
+            from dataclasses import replace
+
+            metadata = dict(snapshot.metadata)
+            metadata.update(stamped_meta)
+            return replace(snapshot, metadata=metadata)
+
+        with (
+            patch.object(
+                strategy_runtime_module,
+                "resolve_strategy_metadata",
+                return_value=SimpleNamespace(display_name="Crypto Live Pool Rotation"),
+            ),
+            patch(
+                "quant_platform_kit.strategy_lifecycle.live_equity.stamp_consecutive_losses_on_snapshot",
+                side_effect=_stamp,
+            ) as stamp,
+        ):
+            runtime.evaluate(
+                prices={"BTCUSDT": 60000.0, "ETHUSDT": 3000.0},
+                trend_indicators={"ETHUSDT": {"close": 3000.0}},
+                btc_snapshot={"regime_on": True},
+                account_metrics={
+                    "total_equity": 10000.0,
+                    "cash_usdt": 2000.0,
+                    "trend_value": 3000.0,
+                    "dca_value": 5000.0,
+                },
+                trend_universe_symbols=("ETHUSDT",),
+                balances={"BTCUSDT": 0.0833333333, "ETHUSDT": 1.0},
+                state={},
+                translator=lambda key, **_kwargs: key,
+                now_utc=datetime(2026, 4, 7, tzinfo=timezone.utc),
+            )
+
+        stamp.assert_called_once()
+        self.assertEqual(entrypoint.ctx.portfolio.metadata["consecutive_losses"], 5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -91,8 +91,8 @@ class WatchdogWorkflowTests(unittest.TestCase):
         requirement = _dependency("quant-platform-kit @ ")
         lock = LOCK.read_text(encoding="utf-8")
 
-        self.assertIn("QuantPlatformKit.git?rev=53b2ca73a5a50257b5d1a3c769b75c40924e4ba6", lock)
-        self.assertIn("@53b2ca73a5a50257b5d1a3c769b75c40924e4ba6", requirement)
+        self.assertIn("QuantPlatformKit.git?rev=69a0256934d081b5ef309a885384b9eb9f62cf90", lock)
+        self.assertIn("@69a0256934d081b5ef309a885384b9eb9f62cf90", requirement)
         self.assertNotIn("@0af622ac9d47f7ef93f9379f9ded314c27a344ff", lock)
 
     def test_crypto_strategies_pin_matches_qpk_health_dependency(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -211,7 +211,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "python-binance" },
-    { name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=53b2ca73a5a50257b5d1a3c769b75c40924e4ba6" },
+    { name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=69a0256934d081b5ef309a885384b9eb9f62cf90" },
     { name = "requests" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.12" },
 ]
@@ -1614,7 +1614,7 @@ wheels = [
 [[package]]
 name = "quant-platform-kit"
 version = "0.10.0"
-source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=53b2ca73a5a50257b5d1a3c769b75c40924e4ba6#53b2ca73a5a50257b5d1a3c769b75c40924e4ba6" }
+source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=69a0256934d081b5ef309a885384b9eb9f62cf90#53b2ca73a5a50257b5d1a3c769b75c40924e4ba6" }
 
 [[package]]
 name = "regex"


### PR DESCRIPTION
## Summary
- Stamp `consecutive_losses` onto `portfolio_snapshot` before strategy evaluate via QPK `stamp_consecutive_losses_on_snapshot`
- Bump QPK pin to `69a0256` ([QPK #211](https://github.com/QuantStrategyLab/QuantPlatformKit/pull/211))
- Entrypoint risk gates can trip the >5 consecutive-loss circuit breaker once live equity history exists

## Test plan
- [x] Local stamp unit test
- [ ] CI green

Made with [Cursor](https://cursor.com)