### PR TITLE
fix(runtime): lock qpk to exact git commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,10 @@ test = [
   "ruff>=0.12",
 ]
 
+[tool.uv]
+override-dependencies = [
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@69a0256934d081b5ef309a885384b9eb9f62cf90",
+]
+
 [tool.ruff]
 ignore = ["E701", "E702", "E401", "F541"]

--- a/tests/test_uv_dependency_workflow.py
+++ b/tests/test_uv_dependency_workflow.py
@@ -11,6 +11,8 @@ class UvDependencyWorkflowTests(unittest.TestCase):
         self.assertIn("crypto-strategies @ git+https://github.com/QuantStrategyLab/", pyproject)
         self.assertIn("[project.optional-dependencies]", pyproject)
         self.assertIn("test = [", pyproject)
+        self.assertIn("[tool.uv]", pyproject)
+        self.assertIn('override-dependencies = [', pyproject)
 
     def test_ci_runtime_and_watchdog_use_uv_lock(self) -> None:
         ci = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
@@ -33,6 +35,14 @@ class UvDependencyWorkflowTests(unittest.TestCase):
         self.assertIn("python -m pip install --upgrade pip uv", watchdog)
         self.assertIn("uv sync --frozen --no-dev", watchdog)
         self.assertIn("uv run --no-sync python - <<'PY'", watchdog)
+        self.assertIn(
+            "QuantPlatformKit.git?rev=69a0256934d081b5ef309a885384b9eb9f62cf90#69a0256934d081b5ef309a885384b9eb9f62cf90",
+            lockfile,
+        )
+        self.assertNotIn(
+            "QuantPlatformKit.git?rev=69a0256934d081b5ef309a885384b9eb9f62cf90#53b2ca73a5a50257b5d1a3c769b75c40924e4ba6",
+            lockfile,
+        )
         self.assertNotIn("requirements-lock.txt", ci)
         self.assertNotIn("requirements.txt", ci)
 

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=69a0256934d081b5ef309a885384b9eb9f62cf90" }]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.7.1"
@@ -1614,7 +1617,7 @@ wheels = [
 [[package]]
 name = "quant-platform-kit"
 version = "0.10.0"
-source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=69a0256934d081b5ef309a885384b9eb9f62cf90#53b2ca73a5a50257b5d1a3c769b75c40924e4ba6" }
+source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=69a0256934d081b5ef309a885384b9eb9f62cf90#69a0256934d081b5ef309a885384b9eb9f62cf90" }
 
 [[package]]
 name = "regex"


### PR DESCRIPTION
## Summary
- add a `tool.uv` override for QuantPlatformKit so uv resolves the requested commit exactly
- regenerate `uv.lock` so the runtime venv installs QPK commit `69a025...` instead of stale `53b2ca...`
- extend regression coverage for the exact locked git fragment

## Verification
- python3 -m unittest tests.test_uv_dependency_workflow tests.test_watchdog_workflow
- uv lock --check
- temp venv: `uv sync --frozen --no-dev` then verified `stamp_consecutive_losses_on_snapshot` exists and `direct_url.json` points to `69a025...`