### PR TITLE
chore(governance): harden review gate and qsl metadata

### DIFF
--- a/.github/codex_auto_merge_policy.json
+++ b/.github/codex_auto_merge_policy.json
@@ -44,6 +44,7 @@
     ],
     "timeout_minutes": 20,
     "max_diff_lines": 2400,
+    "auto_converge_after": 3,
     "block_on_review_failure": false
   }
 }

--- a/.github/workflows/codex_pr_review.yml
+++ b/.github/workflows/codex_pr_review.yml
@@ -1,0 +1,30 @@
+name: Codex PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: codex-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    uses: QuantStrategyLab/AIAuditBridge/.github/workflows/codex_pr_review.yml@main
+    with:
+      caller_concurrency_key: pr-${{ github.event.pull_request.number || github.run_id }}
+      allow_unconfigured_backend: true
+      api_fallback_enabled: "false"
+      direct_api_primary_enabled: "false"
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 env:
   GCP_PROJECT_ID: binancequant
   GCP_WORKLOAD_IDENTITY_PROVIDER: projects/677468735457/locations/global/workloadIdentityPools/github-actions/providers/github-main
@@ -33,6 +36,7 @@ jobs:
       )
     runs-on: self-hosted
     timeout-minutes: 60
+    environment: binance-runtime
     permissions:
       actions: read
       contents: write

--- a/qsl.toml
+++ b/qsl.toml
@@ -1,7 +1,7 @@
 [qsl]
 repo = "BinancePlatform"
-tier = "runtime-platform"
-ring = 3
+tier = "runtime"
+upgrade_ring = "ring_d"
 allow_legacy = false
 enforce_bundle = true
 owner = "runtime-platform"
@@ -13,4 +13,4 @@ quant_platform_kit = "69a0256934d081b5ef309a885384b9eb9f62cf90"
 crypto_strategies = "ef78312d7653095f585c4f75d45bf765bedc2751"
 
 [qsl.compat]
-bundle = "2026.07.2"
+bundle = "2026.07.3"


### PR DESCRIPTION
Part of the QuantStrategyLab P0-P5 hardening and convergence wave.

Highlights:
- tighten governance / QSL metadata / runtime reporting where applicable
- keep changes minimal and repository-scoped

Local validation was run before push in the Codex execution session.
