### PR TITLE
fix(runtime): bootstrap pip before uv install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,14 @@ jobs:
             return 1
           }
 
+          ensure_venv_pip() {
+            if "$VENV_PATH/bin/python" -m pip --version >/dev/null 2>&1; then
+              return 0
+            fi
+            echo "pip missing from dependency venv; bootstrapping with ensurepip."
+            "$VENV_PATH/bin/python" -m ensurepip --upgrade
+          }
+
           if [ ! -x "$VENV_PATH/bin/python" ]; then
             echo "Creating dependency venv at $VENV_PATH."
             rm -rf "$VENV_PATH"
@@ -103,6 +111,7 @@ jobs:
             rm -f "$HASH_FILE" "$PYTHON_VERSION_FILE"
           fi
 
+          ensure_venv_pip
           install_with_retry "Install uv into dependency venv" \
             "$VENV_PATH/bin/python" -m pip install --upgrade pip uv
 

--- a/tests/test_uv_dependency_workflow.py
+++ b/tests/test_uv_dependency_workflow.py
@@ -27,6 +27,7 @@ class UvDependencyWorkflowTests(unittest.TestCase):
         self.assertIn("https://raw.githubusercontent.com/QuantStrategyLab/QuantPlatformKit/main/QPK_PIN", ci)
         self.assertIn("uv lock --check", ci)
         self.assertIn('LOCK_FILE="uv.lock"', runtime)
+        self.assertIn('"$VENV_PATH/bin/python" -m ensurepip --upgrade', runtime)
         self.assertIn('"$VENV_PATH/bin/python" -m pip install --upgrade pip uv', runtime)
         self.assertIn('export UV_PROJECT_ENVIRONMENT="$VENV_PATH"', runtime)
         self.assertIn('UV_BIN="$VENV_PATH/bin/uv"', runtime)

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -60,6 +60,7 @@ class WatchdogWorkflowTests(unittest.TestCase):
 
         self.assertIn('LOCK_FILE="uv.lock"', text)
         self.assertIn('HASH_FILE="${CACHE_ROOT}/uv.lock.sha256"', text)
+        self.assertIn('"$VENV_PATH/bin/python" -m ensurepip --upgrade', text)
         self.assertIn('"$VENV_PATH/bin/python" -m pip install --upgrade pip uv', text)
         self.assertIn('export UV_PROJECT_ENVIRONMENT="$VENV_PATH"', text)
         self.assertIn('UV_BIN="$VENV_PATH/bin/uv"', text)


### PR DESCRIPTION
## Summary
- restore pip with `python -m ensurepip --upgrade` before each runtime uv bootstrap
- keep the cached dependency venv approach but tolerate uv pruning pip from the previous sync
- extend workflow regression checks for the ensurepip bootstrap path

## Verification
- python3 -m unittest tests.test_uv_dependency_workflow tests.test_watchdog_workflow
- temp venv reproduction: after `uv sync --frozen --no-dev`, `python -m pip` failed, then `python -m ensurepip --upgrade` restored pip and `uv` installation succeeded