### PR TITLE
chore(ci): harden Codex PR review gate

### DIFF
--- a/.github/workflows/codex_pr_review.yml
+++ b/.github/workflows/codex_pr_review.yml
@@ -1,7 +1,7 @@
 name: Codex PR Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -19,7 +19,7 @@ jobs:
     uses: QuantStrategyLab/AIAuditBridge/.github/workflows/codex_pr_review.yml@main
     with:
       caller_concurrency_key: pr-${{ github.event.pull_request.number || github.run_id }}
-      allow_unconfigured_backend: true
+      allow_unconfigured_backend: false
       api_fallback_enabled: "false"
       direct_api_primary_enabled: "false"
     secrets: inherit

--- a/.github/workflows/codex_pr_review.yml
+++ b/.github/workflows/codex_pr_review.yml
@@ -22,7 +22,10 @@ jobs:
       allow_unconfigured_backend: false
       api_fallback_enabled: "false"
       direct_api_primary_enabled: "false"
-    secrets: inherit
+    # The centralized workflow is fail-closed and only needs the service URL.
+    # Do not expose unrelated repository or organization secrets to it.
+    secrets:
+      CODEX_AUDIT_SERVICE_URL: ${{ secrets.CODEX_AUDIT_SERVICE_URL }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Migrate the caller to the standard reusable Codex PR review wrapper with `pull_request_target`.
- Keep minimal permissions and PR concurrency; disable unconfigured, API fallback, and direct API review paths.

## Validation
- `actionlint .github/workflows/codex_pr_review.yml`
- `git diff --check`