### PR TITLE
chore(deps): align QPK pin to de18c2e9d93b

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "QuantStrategyLab platform layer for Binance exchange."
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@2381aa4577e9fd6329053a73a1c888929170eaf3",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@de18c2e9d93bcfc2220148a99749447059a6f4c6",
   "crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@ef78312d7653095f585c4f75d45bf765bedc2751",
   "python-binance",
   "pandas",
@@ -23,7 +23,7 @@ test = [
 
 [tool.uv]
 override-dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@2381aa4577e9fd6329053a73a1c888929170eaf3",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@de18c2e9d93bcfc2220148a99749447059a6f4c6",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=2381aa4577e9fd6329053a73a1c888929170eaf3" }]
+overrides = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=de18c2e9d93bcfc2220148a99749447059a6f4c6" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -214,7 +214,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "python-binance" },
-    { name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=2381aa4577e9fd6329053a73a1c888929170eaf3" },
+    { name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=de18c2e9d93bcfc2220148a99749447059a6f4c6" },
     { name = "requests" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.12" },
 ]
@@ -1617,7 +1617,7 @@ wheels = [
 [[package]]
 name = "quant-platform-kit"
 version = "0.10.0"
-source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=2381aa4577e9fd6329053a73a1c888929170eaf3#2381aa4577e9fd6329053a73a1c888929170eaf3" }
+source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=de18c2e9d93bcfc2220148a99749447059a6f4c6#de18c2e9d93bcfc2220148a99749447059a6f4c6" }
 
 [[package]]
 name = "regex"


### PR DESCRIPTION
## Summary
- 自动将 QPK pin 对齐到 `de18c2e9d93b`
- 若仓库使用 `uv.lock`，同步刷新 lockfile

## Test plan
- [ ] Repo CI 转绿

🤖 Generated with Claude Code