### PR TITLE
chore(deps): align QPK pin to 618b786d9d95

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "QuantStrategyLab platform layer for Binance exchange."
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@56a03364d517fd0e2efb2c4d4add8a785fc5e857",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@618b786d9d95c87ba5c4d08c088c8bcac7817644",
   "crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@ef78312d7653095f585c4f75d45bf765bedc2751",
   "python-binance",
   "pandas",
@@ -23,7 +23,7 @@ test = [
 
 [tool.uv]
 override-dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@56a03364d517fd0e2efb2c4d4add8a785fc5e857",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@618b786d9d95c87ba5c4d08c088c8bcac7817644",
 ]
 
 [tool.ruff]

--- a/qsl.toml
+++ b/qsl.toml
@@ -9,7 +9,7 @@ expires_at = "2026-09-30"
 next_action = "keep uv.lock current and maintain QPK/CryptoStrategies pin consistency"
 
 [qsl.requires]
-quant_platform_kit = "56a03364d517fd0e2efb2c4d4add8a785fc5e857"
+quant_platform_kit = "618b786d9d95c87ba5c4d08c088c8bcac7817644"
 crypto_strategies = "ef78312d7653095f585c4f75d45bf765bedc2751"
 
 [qsl.compat]

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=56a03364d517fd0e2efb2c4d4add8a785fc5e857" }]
+overrides = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=618b786d9d95c87ba5c4d08c088c8bcac7817644" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -214,7 +214,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "python-binance" },
-    { name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=56a03364d517fd0e2efb2c4d4add8a785fc5e857" },
+    { name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=618b786d9d95c87ba5c4d08c088c8bcac7817644" },
     { name = "requests" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.12" },
 ]
@@ -1617,7 +1617,7 @@ wheels = [
 [[package]]
 name = "quant-platform-kit"
 version = "0.10.0"
-source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=56a03364d517fd0e2efb2c4d4add8a785fc5e857#56a03364d517fd0e2efb2c4d4add8a785fc5e857" }
+source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=618b786d9d95c87ba5c4d08c088c8bcac7817644#618b786d9d95c87ba5c4d08c088c8bcac7817644" }
 
 [[package]]
 name = "regex"


### PR DESCRIPTION
## Summary
- 自动将 QPK pin 对齐到 `618b786d9d95`
- 若仓库使用 `uv.lock`，同步刷新 lockfile

## Test plan
- [ ] Repo CI 转绿

🤖 Generated with Claude Code