### PR TITLE
chore(qsl): adopt compatibility bundle 2026.07.4

### DIFF
--- a/qsl.toml
+++ b/qsl.toml
@@ -13,4 +13,4 @@ quant_platform_kit = "651c9ac4f37ce6e7fe1bac84dc7646cd5abc9e6e"
 crypto_strategies = "ef78312d7653095f585c4f75d45bf765bedc2751"
 
 [qsl.compat]
-bundle = "2026.07.3"
+bundle = "2026.07.4"


### PR DESCRIPTION
## Summary
- adopt central QSL compatibility bundle 2026.07.4
- no runtime, order, deploy, or secret changes

## Validation
- metadata-only change; existing repository CI and Codex review gate are required
