### PR TITLE
chore: dismiss Dependabot review requests

### DIFF
--- a/.github/workflows/dependabot_review_request_cleanup.yml
+++ b/.github/workflows/dependabot_review_request_cleanup.yml
@@ -1,0 +1,73 @@
+name: Dismiss Dependabot Review Request
+
+"on":
+  pull_request_target:
+    types: [review_requested]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  dismiss-review-request:
+    if: >-
+      (github.event.pull_request.user.login == 'dependabot[bot]' ||
+       github.event.pull_request.user.login == 'app/dependabot') &&
+      github.event.requested_reviewer.login == 'Pigbibi' &&
+      (github.actor == 'dependabot[bot]' || github.actor == 'app/dependabot')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Dismiss Pigbibi review request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEWER: Pigbibi
+        run: |
+          set -euo pipefail
+          latest_review_request_actor() {
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/timeline?per_page=100" |
+              jq -sr --arg reviewer "${REVIEWER}" \
+                '[.[][] | select(.event == "review_requested" and .requested_reviewer.login == $reviewer)][-1].actor.login // ""'
+          }
+
+          review_requests="$(gh pr view "${PR_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --json reviewRequests \
+            --jq '.reviewRequests[].login')"
+          if ! grep -Fqx "${REVIEWER}" <<<"${review_requests}"; then
+            echo "No review request for ${REVIEWER}; nothing to dismiss." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          latest_request_actor="$(latest_review_request_actor)"
+          case "${latest_request_actor}" in
+            'dependabot[bot]'|'app/dependabot') ;;
+            *)
+              echo "Latest review request was made by ${latest_request_actor:-<unknown>}; preserving it." >> "${GITHUB_STEP_SUMMARY}"
+              exit 0
+              ;;
+          esac
+
+          gh api --method DELETE \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" \
+            -f "reviewers[]=${REVIEWER}"
+
+          latest_request_actor="$(latest_review_request_actor)"
+          case "${latest_request_actor}" in
+            'dependabot[bot]'|'app/dependabot')
+              echo "Dismissed Dependabot review request for ${REVIEWER}." >> "${GITHUB_STEP_SUMMARY}"
+              ;;
+            *)
+              gh api --method POST \
+                "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" \
+                -f "reviewers[]=${REVIEWER}"
+              echo "Restored review request made by ${latest_request_actor:-<unknown>}." >> "${GITHUB_STEP_SUMMARY}"
+              ;;
+          esac


### PR DESCRIPTION
## What changed

- dismiss Pigbibi review requests automatically generated for Dependabot PRs
- recognize both dependabot[bot] and app/dependabot identities
- require the review-request event actor to be Dependabot
- re-check the latest Pigbibi review-request actor from the PR timeline immediately before deletion
- preserve later or concurrent review requests made by maintainers
- keep concurrent review-request runs instead of cancelling the matching cleanup
- use pull_request_target with metadata-only GitHub API access and no checkout

## Why

These repositories already auto-merge eligible non-major Dependabot updates after CI, but CODEOWNERS creates redundant review notifications. Event-actor and timeline checks let the workflow remove only bot-generated requests without touching human review requests, including race conditions while a run is queued.

## Validation

- verified automatic CODEOWNERS timeline actor on a historical Dependabot PR
- verified both supported Dependabot identities
- verified requested reviewer, event actor, and latest timeline actor conditions
- verified API errors fail instead of being treated as no match
- verified no checkout or execution of PR code
- bash syntax check
- git diff --check