### PR TITLE
fix dismiss all Dependabot review requests

### DIFF
--- a/.github/workflows/dependabot_review_request_cleanup.yml
+++ b/.github/workflows/dependabot_review_request_cleanup.yml
@@ -6,20 +6,14 @@ name: Dismiss Dependabot Review Request
 
 permissions:
   contents: read
-  issues: read
   pull-requests: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
 
 jobs:
   dismiss-review-request:
     if: >-
       (github.event.pull_request.user.login == 'dependabot[bot]' ||
        github.event.pull_request.user.login == 'app/dependabot') &&
-      github.event.requested_reviewer.login == 'Pigbibi' &&
-      (github.actor == 'dependabot[bot]' || github.actor == 'app/dependabot')
+      github.event.requested_reviewer.login == 'Pigbibi'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -30,17 +24,6 @@ jobs:
           REVIEWER: Pigbibi
         run: |
           set -euo pipefail
-          review_events() {
-            gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/timeline?per_page=100" |
-              jq -sc --arg reviewer "${REVIEWER}" '
-                [.[][] | select(
-                  (.event == "review_requested" or .event == "review_request_removed") and
-                  .requested_reviewer.login == $reviewer
-                )]
-              '
-          }
-
           current_review_requests() {
             gh pr view "${PR_NUMBER}" \
               --repo "${GITHUB_REPOSITORY}" \
@@ -51,24 +34,6 @@ jobs:
           review_requests="$(current_review_requests)"
           if ! grep -Fqx "${REVIEWER}" <<<"${review_requests}"; then
             echo "No review request for ${REVIEWER}; nothing to dismiss." >> "${GITHUB_STEP_SUMMARY}"
-            exit 0
-          fi
-
-          events_before="$(review_events)"
-          latest_event="$(jq -r '.[-1].event // ""' <<<"${events_before}")"
-          latest_actor="$(jq -r '.[-1].actor.login // ""' <<<"${events_before}")"
-          case "${latest_event}:${latest_actor}" in
-            'review_requested:dependabot[bot]'|'review_requested:app/dependabot') ;;
-            *)
-              echo "Latest review event was ${latest_event:-<unknown>} by ${latest_actor:-<unknown>}; preserving the request." >> "${GITHUB_STEP_SUMMARY}"
-              exit 0
-              ;;
-          esac
-          baseline_count="$(jq 'length' <<<"${events_before}")"
-
-          review_requests="$(current_review_requests)"
-          if ! grep -Fqx "${REVIEWER}" <<<"${review_requests}"; then
-            echo "Review request was removed during cleanup; nothing to dismiss." >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi
 
@@ -83,26 +48,4 @@ jobs:
             exit 1
           fi
 
-          events_after="$(review_events)"
-          human_intent="$(jq -r --argjson baseline "${baseline_count}" '
-            [.[$baseline:][] | select(
-              .actor.login != "dependabot[bot]" and
-              .actor.login != "app/dependabot" and
-              .actor.login != "github-actions[bot]" and
-              .actor.login != "github-actions"
-            )][-1].event // ""
-          ' <<<"${events_after}")"
-
-          if [ "${human_intent}" = 'review_requested' ]; then
-            review_requests="$(current_review_requests)"
-            if ! grep -Fqx "${REVIEWER}" <<<"${review_requests}"; then
-              gh api --method POST \
-                "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" \
-                -f "reviewers[]=${REVIEWER}"
-            fi
-            echo "Preserved a concurrent human review request." >> "${GITHUB_STEP_SUMMARY}"
-          elif [ "${human_intent}" = 'review_request_removed' ]; then
-            echo "Preserved a concurrent human review removal." >> "${GITHUB_STEP_SUMMARY}"
-          else
-            echo "Dismissed Dependabot review request for ${REVIEWER}." >> "${GITHUB_STEP_SUMMARY}"
-          fi
+          echo "Dismissed Dependabot review request for ${REVIEWER}." >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Policy

All review requests targeting Pigbibi on Dependabot-authored PRs are intentionally dismissed, including later manual re-requests. Major dependency updates remain open because the existing Dependabot auto-merge workflow excludes semver-major updates, but they no longer generate review-request notifications.

## What changed

- handle review_requested events for both dependabot[bot] and app/dependabot PR authors
- remove the request regardless of the event actor
- keep API failures visible while treating an already-removed request as success
- do not checkout or execute PR code

## Validation

- bash syntax check
- git diff --check