### PR TITLE
chore(deps): align QPK pin to 230854059c11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "QuantStrategyLab platform layer for Binance exchange."
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@61783fdaee869bfeedd4289ae4b7f27104513759",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@230854059c11a3711fed4bd997e3f8a7f37cba32",
   "crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@ef78312d7653095f585c4f75d45bf765bedc2751",
   "python-binance",
   "pandas",
@@ -23,7 +23,7 @@ test = [
 
 [tool.uv]
 override-dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@61783fdaee869bfeedd4289ae4b7f27104513759",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@230854059c11a3711fed4bd997e3f8a7f37cba32",
 ]
 
 [tool.ruff]

--- a/qsl.toml
+++ b/qsl.toml
@@ -9,7 +9,7 @@ expires_at = "2026-09-30"
 next_action = "keep uv.lock current and maintain QPK/CryptoStrategies pin consistency"
 
 [qsl.requires]
-quant_platform_kit = "61783fdaee869bfeedd4289ae4b7f27104513759"
+quant_platform_kit = "230854059c11a3711fed4bd997e3f8a7f37cba32"
 crypto_strategies = "ef78312d7653095f585c4f75d45bf765bedc2751"
 
 [qsl.compat]

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=61783fdaee869bfeedd4289ae4b7f27104513759" }]
+overrides = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=230854059c11a3711fed4bd997e3f8a7f37cba32" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -214,7 +214,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "python-binance" },
-    { name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=61783fdaee869bfeedd4289ae4b7f27104513759" },
+    { name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=230854059c11a3711fed4bd997e3f8a7f37cba32" },
     { name = "requests" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.12" },
 ]
@@ -1617,7 +1617,7 @@ wheels = [
 [[package]]
 name = "quant-platform-kit"
 version = "0.10.0"
-source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=61783fdaee869bfeedd4289ae4b7f27104513759#61783fdaee869bfeedd4289ae4b7f27104513759" }
+source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=230854059c11a3711fed4bd997e3f8a7f37cba32#230854059c11a3711fed4bd997e3f8a7f37cba32" }
 
 [[package]]
 name = "regex"


### PR DESCRIPTION
## Summary
- 自动将 QPK pin 对齐到 `230854059c11`
- 若仓库使用 `uv.lock`，同步刷新 lockfile

## Test plan
- [ ] Repo CI 转绿

🤖 Generated with Claude Code