### PR TITLE
chore(deps): align QSL 2026.08 runtime bundle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 description = "QuantStrategyLab platform layer for Binance exchange."
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@730ad9f3983bd90cd75adecb67fcf483ffb96736",
-  "crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@ef78312d7653095f585c4f75d45bf765bedc2751",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@3acab1923a97b805b077c85c6c19657be0143bac",
+  "crypto-strategies @ git+https://github.com/QuantStrategyLab/CryptoStrategies.git@d2b43112154c35c7b6c2651a240054926a779ae9",
   "python-binance",
   "pandas",
   "numpy",
@@ -23,7 +23,7 @@ test = [
 
 [tool.uv]
 override-dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@730ad9f3983bd90cd75adecb67fcf483ffb96736",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@3acab1923a97b805b077c85c6c19657be0143bac",
 ]
 
 [tool.ruff]

--- a/qsl.toml
+++ b/qsl.toml
@@ -9,8 +9,8 @@ expires_at = "2026-09-30"
 next_action = "keep uv.lock current and maintain QPK/CryptoStrategies pin consistency"
 
 [qsl.requires]
-quant_platform_kit = "730ad9f3983bd90cd75adecb67fcf483ffb96736"
-crypto_strategies = "ef78312d7653095f585c4f75d45bf765bedc2751"
+quant_platform_kit = "3acab1923a97b805b077c85c6c19657be0143bac"
+crypto_strategies = "d2b43112154c35c7b6c2651a240054926a779ae9"
 
 [qsl.compat]
-bundle = "2026.07.4"
+bundle = "2026.08.0"

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=730ad9f3983bd90cd75adecb67fcf483ffb96736" }]
+overrides = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=3acab1923a97b805b077c85c6c19657be0143bac" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -206,7 +206,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "crypto-strategies", git = "https://github.com/QuantStrategyLab/CryptoStrategies.git?rev=ef78312d7653095f585c4f75d45bf765bedc2751" },
+    { name = "crypto-strategies", git = "https://github.com/QuantStrategyLab/CryptoStrategies.git?rev=d2b43112154c35c7b6c2651a240054926a779ae9" },
     { name = "functions-framework" },
     { name = "google-cloud-firestore" },
     { name = "google-cloud-storage" },
@@ -214,7 +214,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "python-binance" },
-    { name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=730ad9f3983bd90cd75adecb67fcf483ffb96736" },
+    { name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=3acab1923a97b805b077c85c6c19657be0143bac" },
     { name = "requests" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.12" },
 ]
@@ -446,7 +446,7 @@ wheels = [
 [[package]]
 name = "crypto-strategies"
 version = "0.4.11"
-source = { git = "https://github.com/QuantStrategyLab/CryptoStrategies.git?rev=ef78312d7653095f585c4f75d45bf765bedc2751#ef78312d7653095f585c4f75d45bf765bedc2751" }
+source = { git = "https://github.com/QuantStrategyLab/CryptoStrategies.git?rev=d2b43112154c35c7b6c2651a240054926a779ae9#d2b43112154c35c7b6c2651a240054926a779ae9" }
 dependencies = [
     { name = "quant-platform-kit" },
 ]
@@ -1617,7 +1617,7 @@ wheels = [
 [[package]]
 name = "quant-platform-kit"
 version = "0.10.0"
-source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=730ad9f3983bd90cd75adecb67fcf483ffb96736#730ad9f3983bd90cd75adecb67fcf483ffb96736" }
+source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=3acab1923a97b805b077c85c6c19657be0143bac#3acab1923a97b805b077c85c6c19657be0143bac" }
 
 [[package]]
 name = "regex"


### PR DESCRIPTION
## Summary

- Align the runtime repository with the QuantRuntimeSettings 2026.08 compatibility bundle.
- Update direct QPK and strategy pins, `qsl.toml`, and `uv.lock` together.

## Why

CI requires QPK `3acab1923a97…`; the prior manifests and declared 2026.07.4 bundle were stale. This makes the declared compatibility contract, source dependencies, and lock file agree.

## Safety

- Exact immutable Git revisions only.
- No strategy, broker, runtime, credential, or deployment behavior changes.

## Validation

- `qslctl.py check --repo-root <repo>`
- `uv lock --check`
- `check_qpk_pin_consistency.py --root <repo> --pin-file QPK_PIN`
- Workspace report: runtime ring strict drift is zero.