### PR TITLE
ci: harden Binance monitoring workflows

### DIFF
--- a/.github/workflows/runtime-heartbeat.yml
+++ b/.github/workflows/runtime-heartbeat.yml
@@ -39,11 +39,12 @@ jobs:
       RUNTIME_HEARTBEAT_MAX_CONSECUTIVE_MISSES: ${{ vars.RUNTIME_HEARTBEAT_MAX_CONSECUTIVE_MISSES || '2' }}
       RUNTIME_HEARTBEAT_FAIL_WORKFLOW_ON_ALERT: ${{ inputs.fail_workflow_on_alert || vars.RUNTIME_HEARTBEAT_FAIL_WORKFLOW_ON_ALERT || 'true' }}
       GLOBAL_TELEGRAM_CHAT_ID: ${{ vars.GLOBAL_TELEGRAM_CHAT_ID }}
-      TG_TOKEN: ${{ secrets.TG_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Check recent Runtime workflow success
+        env:
+          TG_TOKEN: ${{ secrets.TG_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/runtime_workflow_heartbeat.py

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -43,12 +43,12 @@ jobs:
             echo "::error::Repository OIDC identity variables do not match the reviewed identity contract."
             exit 1
           fi
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/tests/test_runtime_workflow_security.py
+++ b/tests/test_runtime_workflow_security.py
@@ -3,7 +3,9 @@ import re
 
 
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "main.yml"
-FULL_SHA_ACTION = re.compile(r"uses:\s+[^\s@]+@[0-9a-f]{40}(?:\s+#\s+v\d+)?$")
+WATCHDOG_WORKFLOW = WORKFLOW.with_name("watchdog.yml")
+HEARTBEAT_WORKFLOW = WORKFLOW.with_name("runtime-heartbeat.yml")
+FULL_SHA_ACTION = re.compile(r"(?:-\s+)?uses:\s+[^\s@]+@[0-9a-f]{40}(?:\s+#\s+v\d+)?$")
 
 
 def _job_block(workflow: str, job: str, next_job: str | None = None) -> str:
@@ -32,3 +34,22 @@ def test_broker_job_cannot_write_repository_contents() -> None:
     assert "BINANCE_API_SECRET" not in log_job
     assert "contents: write" in log_job
     assert "actions/download-artifact@" in log_job
+
+
+def test_oidc_and_notification_workflows_pin_remote_actions() -> None:
+    for path in (WATCHDOG_WORKFLOW, HEARTBEAT_WORKFLOW):
+        workflow = path.read_text(encoding="utf-8")
+        action_lines = [line.strip() for line in workflow.splitlines() if "uses:" in line]
+
+        assert action_lines
+        assert all(FULL_SHA_ACTION.fullmatch(line) for line in action_lines)
+
+
+def test_heartbeat_secrets_are_only_available_to_check_step() -> None:
+    workflow = HEARTBEAT_WORKFLOW.read_text(encoding="utf-8")
+    job_env = workflow[workflow.index("    env:\n") : workflow.index("    steps:\n")]
+    check_step = workflow[workflow.index("      - name: Check recent Runtime workflow success") :]
+
+    assert "secrets." not in job_env
+    assert "TG_TOKEN: ${{ secrets.TG_TOKEN }}" in check_step
+    assert "GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in check_step

--- a/tests/test_watchdog_workflow.py
+++ b/tests/test_watchdog_workflow.py
@@ -94,11 +94,14 @@ class WatchdogWorkflowTests(unittest.TestCase):
             text,
         )
         preflight = text.index("- name: Validate deployment identity configuration")
-        checkout = text.index("- uses: actions/checkout@v6")
+        checkout = text.index("- uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6")
         auth = text.index("- name: Authenticate to Google Cloud")
         self.assertLess(preflight, checkout)
         self.assertLess(preflight, auth)
-        self.assertIn("uses: google-github-actions/auth@v3", text)
+        self.assertIn(
+            "uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3",
+            text,
+        )
         self.assertIn("workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}", text)
         self.assertIn("service_account: ${{ env.GCP_WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}", text)
         self.assertIn("WATCHDOG_MAX_AGE_SECONDS: ${{ vars.WATCHDOG_MAX_AGE_SECONDS || '4500' }}", text)


### PR DESCRIPTION
## Summary
- pin OIDC watchdog and runtime heartbeat actions to full commit SHAs
- remove Telegram and GitHub tokens from the heartbeat job environment
- inject those tokens only into the check step that consumes them
- extend workflow security contract tests

## Validation
- 23 targeted tests passed
- actionlint 1.7.12 passed
- Ruff and git diff --check passed

No live permissions, scheduling cadence, alert policy, strategy, or order behavior is changed.