### PR TITLE
ci(runtime): use Node 24 Python setup action

### DIFF
--- a/.github/workflows/runtime-isolation-shadow.yml
+++ b/.github/workflows/runtime-isolation-shadow.yml
@@ -41,7 +41,7 @@ jobs:
           path: external/CryptoStrategies
 
       - name: Setup Python
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
Updates the pinned setup-python v6 commit used by the no-order shadow workflow to its reviewed Node 24 implementation. The first Phase 1 run passed but GitHub annotated the older commit as Node 20 deprecated. No live workflow, secrets, permissions, or broker behavior changes.\n\nValidation: `.venv/bin/python -m pytest -q tests/test_runtime_isolation_shadow.py` (3 passed).