### PR TITLE
fix(runtime): target temporary shadow environment

### DIFF
--- a/.github/workflows/runtime-isolation-shadow.yml
+++ b/.github/workflows/runtime-isolation-shadow.yml
@@ -123,7 +123,11 @@ jobs:
           set -euo pipefail
           python -m pip install --disable-pip-version-check uv==0.11.6
           uv sync --frozen --no-dev
-          uv pip install --no-deps -e external/QuantPlatformKit -e external/CryptoStrategies
+          uv pip install \
+            --python "$UV_PROJECT_ENVIRONMENT/bin/python" \
+            --no-deps \
+            -e external/QuantPlatformKit \
+            -e external/CryptoStrategies
 
       - name: Run current-runner fixed-input no-order replay
         env:

--- a/tests/test_runtime_isolation_shadow.py
+++ b/tests/test_runtime_isolation_shadow.py
@@ -48,6 +48,7 @@ class RuntimeIsolationShadowWorkflowTests(unittest.TestCase):
         self.assertIn("if: ${{ inputs.include_current_runner }}", current_runner_shadow)
         self.assertIn("runs-on: self-hosted", current_runner_shadow)
         self.assertNotIn("environment:", current_runner_shadow)
+        self.assertIn('--python "$UV_PROJECT_ENVIRONMENT/bin/python"', current_runner_shadow)
         self.assertIn("contents: read", workflow)
         self.assertNotIn("id-token: write", workflow)
         self.assertNotIn("environment:", workflow)


### PR DESCRIPTION
The self-hosted no-order shadow created and populated its job-local UV_PROJECT_ENVIRONMENT, but the editable dependency install did not select that custom environment and failed before fixture execution. Explicitly pass the temporary interpreter to uv pip and protect the wiring with a workflow contract test.

Safety: no broker secret, OIDC, live workflow, scheduler, or trading behavior changes.

Validation:
- 5 targeted tests passed
- ruff passed
- actionlint v1.7.12 passed
- git diff --check passed

Observed failed run: https://github.com/QuantStrategyLab/BinancePlatform/actions/runs/32644766682