### PR TITLE
ci: wait for Dependabot merge requirements

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -88,4 +88,4 @@ jobs:
         if: steps.merge_guard.outputs.should_merge == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge "${{ steps.pr.outputs.pr_number }}" --repo "${GITHUB_REPOSITORY}" --rebase --delete-branch --match-head-commit "${{ steps.pr.outputs.head_sha }}"
+        run: gh pr merge "${{ steps.pr.outputs.pr_number }}" --repo "${GITHUB_REPOSITORY}" --auto --rebase --delete-branch --match-head-commit "${{ steps.pr.outputs.head_sha }}"


### PR DESCRIPTION
## Summary
- enable GitHub auto-merge only after the existing Dependabot eligibility and exact-head checks pass
- let required status checks settle before the merge is attempted

## Validation
- git diff --check
- repository CI/actionlint pending

No runtime deployment, strategy, or secret configuration changed.